### PR TITLE
Fix logger text printout

### DIFF
--- a/boofuzz/fuzz_logger_text.py
+++ b/boofuzz/fuzz_logger_text.py
@@ -1,4 +1,5 @@
 from __future__ import print_function
+from builtins import bytes
 import sys
 import time
 from boofuzz import helpers
@@ -14,7 +15,7 @@ def hex_to_hexstr(input_bytes):
 
     @return: Printable string.
     """
-    return helpers.hex_str(input_bytes) + " '" + bytes(input_bytes) + "'"
+    return helpers.hex_str(input_bytes) + " " + repr(bytes(input_bytes))
 
 
 DEFAULT_HEX_TO_STR = hex_to_hexstr

--- a/boofuzz/fuzz_logger_text.py
+++ b/boofuzz/fuzz_logger_text.py
@@ -1,8 +1,6 @@
 from __future__ import print_function
-
 import sys
 import time
-
 from boofuzz import helpers
 from boofuzz import ifuzz_logger_backend
 
@@ -59,56 +57,55 @@ class FuzzLoggerText(ifuzz_logger_backend.IFuzzLoggerBackend):
         """
         self._file_handle = file_handle
         self._format_raw_bytes = bytes_to_str
-        self._indent_level = 0
 
     def open_test_step(self, description):
-        self._indent_level = self.INDENT_SIZE
-        self._print_log_msg(self.TEST_STEP_FORMAT.format(description))
+        self._print_log_msg(self.TEST_STEP_FORMAT.format(description),
+                            indent_level=1)
 
     def log_check(self, description):
-        self._indent_level = 2 * self.INDENT_SIZE
-        self._print_log_msg(self.LOG_CHECK_FORMAT.format(description))
+        self._print_log_msg(self.LOG_CHECK_FORMAT.format(description),
+                            indent_level=2)
 
     def log_error(self, description):
-        self._indent_level = 2 * self.INDENT_SIZE
-        self._print_log_msg(self.LOG_ERROR_FORMAT.format(description))
+        self._print_log_msg(self.LOG_ERROR_FORMAT.format(description),
+                            indent_level=2)
 
     def log_recv(self, data):
-        self._indent_level = 2 * self.INDENT_SIZE
-        self._print_log_msg(self.LOG_RECV_FORMAT.format(self._format_raw_bytes(data)))
+        self._print_log_msg(self.LOG_RECV_FORMAT.format(self._format_raw_bytes(data)),
+                            indent_level=2)
 
     def log_send(self, data):
-        self._indent_level = 2 * self.INDENT_SIZE
         self._print_log_msg(
-            self.LOG_SEND_FORMAT.format(len(data), self._format_raw_bytes(data)))
+            self.LOG_SEND_FORMAT.format(len(data), self._format_raw_bytes(data)),
+            indent_level=2)
 
     def log_info(self, description):
-        self._indent_level = 2 * self.INDENT_SIZE
-        self._print_log_msg(self.LOG_INFO_FORMAT.format(description))
+        self._print_log_msg(self.LOG_INFO_FORMAT.format(description),
+                            indent_level=2)
 
     def open_test_case(self, test_case_id):
-        self._indent_level = 0
-        self._print_log_msg(self.TEST_CASE_FORMAT.format(test_case_id))
+        self._print_log_msg(self.TEST_CASE_FORMAT.format(test_case_id),
+                            indent_level=0)
 
     def log_fail(self, description=""):
-        self._indent_level = 3 * self.INDENT_SIZE
-        self._print_log_msg(self.LOG_FAIL_FORMAT.format(description))
+        self._print_log_msg(self.LOG_FAIL_FORMAT.format(description),
+                            indent_level=3)
 
     def log_pass(self, description=""):
-        self._indent_level = 3 * self.INDENT_SIZE
-        self._print_log_msg(self.LOG_PASS_FORMAT.format(description))
+        self._print_log_msg(self.LOG_PASS_FORMAT.format(description),
+                            indent_level=3)
 
-    def _print_log_msg(self, msg):
-        msg = _indent_all_lines(msg, self._indent_level)
+    def _print_log_msg(self, msg, indent_level=0):
+        msg = _indent_all_lines(msg, indent_level * self.INDENT_SIZE)
         time_stamp = get_time_stamp()
         print(time_stamp + ' ' + _indent_after_first_line(msg, len(time_stamp) + 1), file=self._file_handle)
 
 
 def _indent_all_lines(lines, amount, ch=' '):
     padding = amount * ch
-    return padding + ('\n'+padding).join(lines.split('\n'))
+    return padding + ('\n' + padding).join(lines.split('\n'))
 
 
 def _indent_after_first_line(lines, amount, ch=' '):
     padding = amount * ch
-    return ('\n'+padding).join(lines.split('\n'))
+    return ('\n' + padding).join(lines.split('\n'))

--- a/boofuzz/fuzz_logger_text.py
+++ b/boofuzz/fuzz_logger_text.py
@@ -99,16 +99,16 @@ class FuzzLoggerText(ifuzz_logger_backend.IFuzzLoggerBackend):
         self._print_log_msg(self.LOG_PASS_FORMAT.format(description))
 
     def _print_log_msg(self, msg):
-        msg = indent_all_lines(msg, self._indent_level)
+        msg = _indent_all_lines(msg, self._indent_level)
         time_stamp = get_time_stamp()
-        print(time_stamp + ' ' + indent_after_first_line(msg, len(time_stamp) + 1), file=self._file_handle)
+        print(time_stamp + ' ' + _indent_after_first_line(msg, len(time_stamp) + 1), file=self._file_handle)
 
 
-def indent_all_lines(lines, amount, ch=' '):
+def _indent_all_lines(lines, amount, ch=' '):
     padding = amount * ch
     return padding + ('\n'+padding).join(lines.split('\n'))
 
 
-def indent_after_first_line(lines, amount, ch=' '):
+def _indent_after_first_line(lines, amount, ch=' '):
     padding = amount * ch
     return ('\n'+padding).join(lines.split('\n'))

--- a/unit_tests/test_fuzz_logger_text.py
+++ b/unit_tests/test_fuzz_logger_text.py
@@ -29,6 +29,96 @@ class TestFuzzLoggerTextFreeFunctions(unittest.TestCase):
         # Then
         self.assertRegexpMatches(s, '\[\d\d\d\d-\d\d-\d\d \d\d:\d\d:\d\d,\d\d\d\]')
 
+    def test_hex_to_hexstr(self):
+        """
+        Given: A set of bytes representing a string with several lines.
+        When: Calling hex_to_hexstr
+        Then: Hex of several-line string is output first, then repr format.
+        """
+        given = "abc\n123\r\nA\n"
+        expected = "61 62 63 0a 31 32 33 0d 0a 41 0a b'abc\\n123\\r\\nA\\n'"
+        self.assertEqual(expected, fuzz_logger_text.hex_to_hexstr(given))
+
+    def test_hex_to_hexstr_all_bytes(self):
+        """
+        Given: List of each byte from 0 to 255.
+        When: Calling hex_to_hexstr on each.
+        Then: For each byte, its hex value is output, followed by its repr
+              value.
+        """
+        # Use a static map so that future changes are detected by the UT,
+        # to avoid Python 3 vs Python 2 errors, etc.
+        expected_results = {
+            0: "b'\\x00'", 1: "b'\\x01'", 2: "b'\\x02'", 3: "b'\\x03'",
+            4: "b'\\x04'", 5: "b'\\x05'", 6: "b'\\x06'", 7: "b'\\x07'",
+            8: "b'\\x08'", 9: "b'\\t'", 10: "b'\\n'", 11: "b'\\x0b'",
+            12: "b'\\x0c'", 13: "b'\\r'", 14: "b'\\x0e'", 15: "b'\\x0f'",
+            16: "b'\\x10'", 17: "b'\\x11'", 18: "b'\\x12'", 19: "b'\\x13'",
+            20: "b'\\x14'", 21: "b'\\x15'", 22: "b'\\x16'", 23: "b'\\x17'",
+            24: "b'\\x18'", 25: "b'\\x19'", 26: "b'\\x1a'", 27: "b'\\x1b'",
+            28: "b'\\x1c'", 29: "b'\\x1d'", 30: "b'\\x1e'", 31: "b'\\x1f'",
+            32: "b' '", 33: "b'!'", 34: 'b\'"\'', 35: "b'#'",
+            36: "b'$'", 37: "b'%'", 38: "b'&'", 39: 'b"\'"',
+            40: "b'('", 41: "b')'", 42: "b'*'", 43: "b'+'",
+            44: "b','", 45: "b'-'", 46: "b'.'", 47: "b'/'",
+            48: "b'0'", 49: "b'1'", 50: "b'2'", 51: "b'3'",
+            52: "b'4'", 53: "b'5'", 54: "b'6'", 55: "b'7'",
+            56: "b'8'", 57: "b'9'", 58: "b':'", 59: "b';'",
+            60: "b'<'", 61: "b'='", 62: "b'>'", 63: "b'?'",
+            64: "b'@'", 65: "b'A'", 66: "b'B'", 67: "b'C'",
+            68: "b'D'", 69: "b'E'", 70: "b'F'", 71: "b'G'",
+            72: "b'H'", 73: "b'I'", 74: "b'J'", 75: "b'K'",
+            76: "b'L'", 77: "b'M'", 78: "b'N'", 79: "b'O'",
+            80: "b'P'", 81: "b'Q'", 82: "b'R'", 83: "b'S'",
+            84: "b'T'", 85: "b'U'", 86: "b'V'", 87: "b'W'",
+            88: "b'X'", 89: "b'Y'", 90: "b'Z'", 91: "b'['",
+            92: "b'\\\\'", 93: "b']'", 94: "b'^'", 95: "b'_'",
+            96: "b'`'", 97: "b'a'", 98: "b'b'", 99: "b'c'",
+            100: "b'd'", 101: "b'e'", 102: "b'f'", 103: "b'g'",
+            104: "b'h'", 105: "b'i'", 106: "b'j'", 107: "b'k'",
+            108: "b'l'", 109: "b'm'", 110: "b'n'", 111: "b'o'",
+            112: "b'p'", 113: "b'q'", 114: "b'r'", 115: "b's'",
+            116: "b't'", 117: "b'u'", 118: "b'v'", 119: "b'w'",
+            120: "b'x'", 121: "b'y'", 122: "b'z'", 123: "b'{'",
+            124: "b'|'", 125: "b'}'", 126: "b'~'", 127: "b'\\x7f'",
+            128: "b'\\x80'", 129: "b'\\x81'", 130: "b'\\x82'", 131: "b'\\x83'",
+            132: "b'\\x84'", 133: "b'\\x85'", 134: "b'\\x86'", 135: "b'\\x87'",
+            136: "b'\\x88'", 137: "b'\\x89'", 138: "b'\\x8a'", 139: "b'\\x8b'",
+            140: "b'\\x8c'", 141: "b'\\x8d'", 142: "b'\\x8e'", 143: "b'\\x8f'",
+            144: "b'\\x90'", 145: "b'\\x91'", 146: "b'\\x92'", 147: "b'\\x93'",
+            148: "b'\\x94'", 149: "b'\\x95'", 150: "b'\\x96'", 151: "b'\\x97'",
+            152: "b'\\x98'", 153: "b'\\x99'", 154: "b'\\x9a'", 155: "b'\\x9b'",
+            156: "b'\\x9c'", 157: "b'\\x9d'", 158: "b'\\x9e'", 159: "b'\\x9f'",
+            160: "b'\\xa0'", 161: "b'\\xa1'", 162: "b'\\xa2'", 163: "b'\\xa3'",
+            164: "b'\\xa4'", 165: "b'\\xa5'", 166: "b'\\xa6'", 167: "b'\\xa7'",
+            168: "b'\\xa8'", 169: "b'\\xa9'", 170: "b'\\xaa'", 171: "b'\\xab'",
+            172: "b'\\xac'", 173: "b'\\xad'", 174: "b'\\xae'", 175: "b'\\xaf'",
+            176: "b'\\xb0'", 177: "b'\\xb1'", 178: "b'\\xb2'", 179: "b'\\xb3'",
+            180: "b'\\xb4'", 181: "b'\\xb5'", 182: "b'\\xb6'", 183: "b'\\xb7'",
+            184: "b'\\xb8'", 185: "b'\\xb9'", 186: "b'\\xba'", 187: "b'\\xbb'",
+            188: "b'\\xbc'", 189: "b'\\xbd'", 190: "b'\\xbe'", 191: "b'\\xbf'",
+            192: "b'\\xc0'", 193: "b'\\xc1'", 194: "b'\\xc2'", 195: "b'\\xc3'",
+            196: "b'\\xc4'", 197: "b'\\xc5'", 198: "b'\\xc6'", 199: "b'\\xc7'",
+            200: "b'\\xc8'", 201: "b'\\xc9'", 202: "b'\\xca'", 203: "b'\\xcb'",
+            204: "b'\\xcc'", 205: "b'\\xcd'", 206: "b'\\xce'", 207: "b'\\xcf'",
+            208: "b'\\xd0'", 209: "b'\\xd1'", 210: "b'\\xd2'", 211: "b'\\xd3'",
+            212: "b'\\xd4'", 213: "b'\\xd5'", 214: "b'\\xd6'", 215: "b'\\xd7'",
+            216: "b'\\xd8'", 217: "b'\\xd9'", 218: "b'\\xda'", 219: "b'\\xdb'",
+            220: "b'\\xdc'", 221: "b'\\xdd'", 222: "b'\\xde'", 223: "b'\\xdf'",
+            224: "b'\\xe0'", 225: "b'\\xe1'", 226: "b'\\xe2'", 227: "b'\\xe3'",
+            228: "b'\\xe4'", 229: "b'\\xe5'", 230: "b'\\xe6'", 231: "b'\\xe7'",
+            232: "b'\\xe8'", 233: "b'\\xe9'", 234: "b'\\xea'", 235: "b'\\xeb'",
+            236: "b'\\xec'", 237: "b'\\xed'", 238: "b'\\xee'", 239: "b'\\xef'",
+            240: "b'\\xf0'", 241: "b'\\xf1'", 242: "b'\\xf2'", 243: "b'\\xf3'",
+            244: "b'\\xf4'", 245: "b'\\xf5'", 246: "b'\\xf6'", 247: "b'\\xf7'",
+            248: "b'\\xf8'", 249: "b'\\xf9'", 250: "b'\\xfa'", 251: "b'\\xfb'",
+            252: "b'\\xfc'", 253: "b'\\xfd'", 254: "b'\\xfe'", 255: "b'\\xff'",
+
+        }
+        for c in range(0, 255):
+            self.assertEqual("{:02x} {}".format(c, expected_results[c]),
+                             fuzz_logger_text.hex_to_hexstr(chr(c)))
+
 
 class TestFuzzLoggerText(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
The default hex_to_str function for FuzzLoggerText now prints out data using Python's repr(string) format, rather than dumping the bytes straight to output. The old approach would mess up console output sometimes. The new approach is safer and escapes most special characters.