### PR TITLE
Testing extra

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -29,14 +29,18 @@ Tips:
  * Use the `-e` option for developer mode, which allows changes to be seen
    automatically without reinstalling:
 
-        `sudo pip -e install ./boofuzz`
+        `sudo pip install -e .`
+
+ * To install unit test dependencies as well:
+
+        `sudo pip install -e .[testing]`
 
 * If you're behind a proxy:
 
         `set HTTPS_PROXY=http://your.proxy.com:port`
     * On Linux, also use `sudo`'s `-E` option:
 
-        `sudo -E pip -e install ./boofuzz`
+        `sudo -E pip install -e .`
 
 Extras
 ------

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,6 @@ setup(
             'future', 'pyserial', 'pydot2==1.0.33', 'tornado==4.0.2',
             'Flask==0.10.1', 'impacket'],
         extras_require={
-            'dev': ['mock'],
+            'testing': ['mock'],
         },
 )


### PR DESCRIPTION
Renamed 'dev' extra to 'testing'. Added to install instructions. Opportunistic fixes to install instructions (`pip install -e` rather than `pip -e install`).