### PR TITLE
Target restart behavior

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@
 
 Fixes
 ~~~~~
+-  Stopping the target process before restarting in is now optional (default is not to stop).
 -  Missing property setters in ``boofuzz.request.Request`` now implemented.
 -  Unit tests now pass on Windows.
 -  Fixed wheel build issue; boofuzz subpackages were missing.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@
 
 Fixes
 ~~~~~
--  Stopping the target process before restarting in is now optional (default is not to stop).
+-  Stopping the target process before restarting is now optional (default is not to stop).
 -  Missing property setters in ``boofuzz.request.Request`` now implemented.
 -  Unit tests now pass on Windows.
 -  Fixed wheel build issue; boofuzz subpackages were missing.

--- a/boofuzz/sessions.py
+++ b/boofuzz/sessions.py
@@ -411,7 +411,7 @@ class Session(pgraph.Graph):
                         and self.restart_interval \
                         and num_cases_actually_fuzzed % self.restart_interval == 0:
                     self._fuzz_data_logger.open_test_step("restart interval of %d reached" % self.restart_interval)
-                    self.restart_target(self.targets[0])
+                    self.restart_target(self.targets[0], stop_first=self.stop_first)
 
                 self._fuzz_current_case(*fuzz_args)
 

--- a/boofuzz/sessions.py
+++ b/boofuzz/sessions.py
@@ -169,11 +169,22 @@ class Connection(pgraph.Edge):
 
 
 class Session(pgraph.Graph):
-    def __init__(self, session_filename=None, skip=0, sleep_time=1.0, restart_interval=0, web_port=26000,
-                 crash_threshold=3, restart_sleep_time=300, fuzz_data_logger=None,
-                 check_data_received_each_request=True,
-                 log_level=logging.INFO, logfile=None, logfile_level=logging.DEBUG,
-                 ):
+    def __init__(
+        self,
+        session_filename=None,
+        skip=0,
+        sleep_time=1.0,
+        restart_interval=0,
+        web_port=26000,
+        crash_threshold=3,
+        restart_sleep_time=300,
+        fuzz_data_logger=None,
+        check_data_received_each_request=True,
+        log_level=logging.INFO,
+        logfile=None,
+        logfile_level=logging.DEBUG,
+        stop_first=False
+    ):
         """
         Extends pgraph.graph and provides a container for architecting protocol dialogs.
 
@@ -247,6 +258,7 @@ class Session(pgraph.Graph):
         self.root.label = self.root.name
         self.last_recv = None
         self.last_send = None
+        self.stop_first = stop_first
 
         self.add_node(self.root)
 
@@ -575,7 +587,7 @@ class Session(pgraph.Graph):
                         self.total_mutant_index += skipped
                         self.fuzz_node.mutant_index += skipped
 
-            self.restart_target(target, stop_first=False)
+            self.restart_target(target, stop_first=self.stop_first)
 
     # noinspection PyUnusedLocal
     def post_send(self, target, fuzz_data_logger, session, sock, *args, **kwargs):


### PR DESCRIPTION
Stopping the target process before it is restarted has been made optional via the instance variable `stop_first` in `boofuzz.session.Session`
