### PR TITLE
Tox check manifest

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -45,38 +45,28 @@ Prep
 
 2. Use :code:`git status` to verify that no superfluous files are present to be included in the source distribution.
 
-3. Use check-manifest_ to update MANIFEST.in:
-  ::
+3. Increment version number from last release according to PEP 0440 and roughly according to the Semantic Versioning guidelines.
 
-      check-manifest -u
-
-4. Increment version number from last release according to PEP 0440 and roughly according to the Semantic Versioning guidelines.
-
-5. Modify CHANGELOG file:
+4. Modify CHANGELOG file:
 
   - Update version number.
   - Edit release notes for publication.
 
-6. Verify tests pass (continuous integration is OK for this).
+5. Verify tests pass (continuous integration is OK for this).
 
-7. Merge release branch.
+6. Merge release branch.
 
 Checks
 ++++++
 
-1. Use check-manifest_ to verify that no files are missing:
-  ::
+1. Use :code:`git status` to verify that no superfluous files are present to be included in the source distribution.
 
-      check-manifest
-
-2. Use :code:`git status` to verify that no superfluous files are present to be included in the source distribution.
-
-3. Build distributions:
+2. Build distributions:
   ::
 
       python setup.py sdist bdist_wheel
 
-4. Visually inspect wheel distribution for correctness.
+3. Visually inspect wheel distribution for correctness.
 
 Release
 +++++++

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,7 @@ setup(
             'future', 'pyserial', 'pydot2==1.0.33', 'tornado==4.0.2',
             'Flask==0.10.1', 'impacket'],
         extras_require={
-            'dev': ['mock', 'pytest', 'pytest-bdd'],
+            'dev': ['check-manifest', 'mock', 'pytest', 'pytest-bdd'],
         },
         classifiers=[
             'Development Status :: 4 - Beta',

--- a/tox.ini
+++ b/tox.ini
@@ -7,5 +7,7 @@ envlist = py27
 deps=pytest
     pytest-bdd
     mock
+    check-manifest
 commands=python -m pytest
+    python -m check_manifest
 install_command = python -m pip install {opts} {packages}


### PR DESCRIPTION
Integrating check-manifest into the build/test process. This allows us to remove some manual steps in the release checklist.