### PR TITLE
Procmon log fail

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,7 @@ Upcoming
 ========
 Fixes
 -----
+-  Boofuzz now properly reports crashes detected by the process monitor. It was calling log_info instead of log_fail.
 -  Boofuzz will no longer crash, but will rather give a helpful error message, if the target refuses socket connections.
 -  Add utils/crash_binning.py to boofuzz/utils, avoiding import errors.
 -  Fix procmon argument processing bug.

--- a/boofuzz/sessions.py
+++ b/boofuzz/sessions.py
@@ -542,10 +542,15 @@ class Session(pgraph.Graph):
             self.netmon_results[self.total_mutant_index] = captured_bytes
 
         # check if our fuzz crashed the target. procmon.post_send() returns False if the target crashes.
-        if target.procmon and not target.procmon.post_send():
-            self._fuzz_data_logger.log_info(
-                "procmon detected crash on test case #{0}: {1}".format(self.total_mutant_index,
-                                                                       target.procmon.get_crash_synopsis()))
+        if target.procmon:
+            self._fuzz_data_logger.open_test_step("Contact process monitor")
+            self._fuzz_data_logger.log_check("procmon.post_send()")
+            if target.procmon.post_send():
+                self._fuzz_data_logger.log_pass("No crash detected.")
+            else:
+                self._fuzz_data_logger.log_fail(
+                    "procmon detected crash on test case #{0}: {1}".format(self.total_mutant_index,
+                                                                           target.procmon.get_crash_synopsis()))
 
     def _process_failures(self, target):
         """Process any failure sin self.crash_synopses.

--- a/process_monitor_unix.py
+++ b/process_monitor_unix.py
@@ -22,7 +22,7 @@ Replicated methods:
     - log
     - post_send
     - pre_send
-    _ start_target
+    - start_target
     - stop_target
     - set_start_commands
     - set_stop_commands


### PR DESCRIPTION
If procmon detects a crash, it is logged with `log_info` instead of `log_fail`. This keeps the restart functionality from being called, resulting in a stopped test.

First reported by: http://stackoverflow.com/q/39298133/461834