### PR TITLE
Socket errors alt

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,18 @@ Features
 --------
 -  Added ``Request.original_value()`` function to render the request as if it were not fuzzed.
    This will help enable reuse of a fuzz definition to generate valid requests.
+-  ``Target.recv()`` now logs an entry before receiving data, in order to help debug receiving issues.
+
+Fixes
+-----
+-  ``SocketConnection`` class now handles more send and receive errors:  ``ECONNABORTED``, ``ECONNRESET``,
+   ``ENETRESET``, and ``ETIMEDOUT``.
+-
+
+Development
+-----------
+-  Added two exceptions: ``BoofuzzTargetConnectionReset`` and ``BoofuzzTargetConnectionAborted``.
+-  These two exceptions are handled in ``sessions.py`` and may be thrown by any ``ITargetConnection`` implementation.
 
 0.0.5
 =====

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -36,3 +36,5 @@ Peter Silberman <peter.silberman@gmail.com>
     - Upcoming file fuzzing capability.
     - Bug reports.
 	
+Markus Piéton <https://github.com/marpie>
+    - Serious bug fix footwork.

--- a/boofuzz/sex.py
+++ b/boofuzz/sex.py
@@ -13,6 +13,14 @@ class BoofuzzTargetConnectionFailedError(BoofuzzError):
     pass
 
 
+class BoofuzzTargetConnectionReset(BoofuzzError):
+    pass
+
+
+class BoofuzzTargetConnectionAborted(BoofuzzError):
+    pass
+
+
 class SullyRuntimeError(Exception):
     pass
 

--- a/boofuzz/socket_connection.py
+++ b/boofuzz/socket_connection.py
@@ -1,8 +1,10 @@
 from __future__ import absolute_import
 import ssl
+import sys
 import httplib
 import socket
 import errno
+from future.utils import raise_
 
 from . import helpers
 from . import itarget_connection
@@ -157,12 +159,12 @@ class SocketConnection(itarget_connection.ITargetConnection):
         except socket.timeout:
             data = bytes('')
         except socket.error as e:
-            if (e.errno == errno.ECONNABORTED) or \
-               (e.errno == errno.ECONNREFUSED) or \
-               (e.errno == errno.ECONNRESET) or  \
-               (e.errno == errno.ENETRESET) or \
-               (e.errno == errno.ETIMEDOUT):
-                data = bytes('')
+            if e.errno == errno.ECONNABORTED:
+                raise_(sex.BoofuzzTargetConnectionAborted, None, sys.exc_info()[2])
+            elif (e.errno == errno.ECONNRESET) or \
+                    (e.errno == errno.ENETRESET) or \
+                    (e.errno == errno.ETIMEDOUT):
+                raise_(sex.BoofuzzTargetConnectionReset, None, sys.exc_info()[2])
             else:
                 raise
 
@@ -183,21 +185,30 @@ class SocketConnection(itarget_connection.ITargetConnection):
         except KeyError:
             pass  # data = data
 
-        if self.proto in ["tcp", "ssl"]:
-            num_sent = self._sock.send(data)
-        elif self.proto == "udp":
-            num_sent = self._sock.sendto(data, (self.host, self.port))
-        elif self.proto == "raw-l2":
-            num_sent = self._sock.sendto(data, (self.host, 0))
-        elif self.proto == "raw-l3":
-            # Address tuple: (interface string,
-            #                 Ethernet protocol number,
-            #                 packet type (recv only),
-            #                 hatype (recv only),
-            #                 Ethernet address)
-            # See man 7 packet for more details.
-            num_sent = self._sock.sendto(data, (self.host, self.ethernet_proto, 0, 0, self.l2_dst))
-        else:
-            raise sex.SullyRuntimeError("INVALID PROTOCOL SPECIFIED: %s" % self.proto)
-
+        try:
+            if self.proto in ["tcp", "ssl"]:
+                num_sent = self._sock.send(data)
+            elif self.proto == "udp":
+                num_sent = self._sock.sendto(data, (self.host, self.port))
+            elif self.proto == "raw-l2":
+                num_sent = self._sock.sendto(data, (self.host, 0))
+            elif self.proto == "raw-l3":
+                # Address tuple: (interface string,
+                #                 Ethernet protocol number,
+                #                 packet type (recv only),
+                #                 hatype (recv only),
+                #                 Ethernet address)
+                # See man 7 packet for more details.
+                num_sent = self._sock.sendto(data, (self.host, self.ethernet_proto, 0, 0, self.l2_dst))
+            else:
+                raise sex.SullyRuntimeError("INVALID PROTOCOL SPECIFIED: %s" % self.proto)
+        except socket.error as e:
+            if e.errno == errno.ECONNABORTED:
+                raise_(sex.BoofuzzTargetConnectionAborted, None, sys.exc_info()[2])
+            elif (e.errno == errno.ECONNRESET) or \
+                    (e.errno == errno.ENETRESET) or \
+                    (e.errno == errno.ETIMEDOUT):
+                raise_(sex.BoofuzzTargetConnectionReset, None, sys.exc_info()[2])
+            else:
+                raise
         return num_sent

--- a/boofuzz/socket_connection.py
+++ b/boofuzz/socket_connection.py
@@ -156,6 +156,15 @@ class SocketConnection(itarget_connection.ITargetConnection):
                 raise sex.SullyRuntimeError("INVALID PROTOCOL SPECIFIED: %s" % self.proto)
         except socket.timeout:
             data = bytes('')
+        except socket.error as e:
+            if (e.errno == errno.ECONNABORTED) or \
+               (e.errno == errno.ECONNREFUSED) or \
+               (e.errno == errno.ECONNRESET) or  \
+               (e.errno == errno.ENETRESET) or \
+               (e.errno == errno.ETIMEDOUT):
+                data = bytes('')
+            else:
+                raise
 
         return data
 

--- a/process_monitor.py
+++ b/process_monitor.py
@@ -377,7 +377,7 @@ if __name__ == "__main__":
     try:
         servlet = ProcessMonitorPedrpcServer("0.0.0.0", PORT, crash_bin, proc_name, ignore_pid, log_level)
         servlet.serve_forever()
-    except Exception, e:
+    except Exception as e:
         # TODO: Add servlet.shutdown
         # TODO: Add KeyboardInterrupt
         ERR("Error starting RPC server!\n\t%s" % e)


### PR DESCRIPTION
Based on conversation in PR #90. This error handling approach reports all socket failures as a UUT failure. The error message for `ECONNABORTED` indicates that there may be other firewall issues, etc.

This approach successfully reports UUT failures based on @marpie use cases as reported in PR #90. For posterity, this is the script I'm using (credit and copyright @marpie):

``` python
#!/usr/bin/env python
import sys
import time

from boofuzz import \
    pedrpc,                 \
    s_binary,               \
    s_block_end,            \
    s_block_start,          \
    s_delim,                \
    s_dword,                \
    s_get,                  \
    s_group,                \
    s_initialize,           \
    s_num_mutations,        \
    s_repeat,               \
    s_size,                 \
    s_static,               \
    s_string,               \
    s_word,                 \
    sessions,               \
    SocketConnection

s_initialize("user")
s_static("USER")
s_delim(" ")
s_static("ftp")
s_static("\r\n")

s_initialize("pass")
s_static("PASS")
s_delim(" ")
s_static("ftp")
s_static("\r\n")

s_initialize("cwd")
s_static("CWD")
s_delim(" ")
s_string("AAAA")
s_static("\r\n")

s_initialize("dele")
s_static("DELE")
s_delim(" ")
s_string("AAAA")
s_static("\r\n")

s_initialize("port")
s_static("PORT")
s_delim(" ")
s_string("AAAA")
s_static("\r\n")

s_initialize("retr")
s_static("RETR")
s_delim(" ")
s_string("AAAA")
s_static("\r\n")

s_initialize("stor")
s_static("STOR")
s_delim(" ")
s_string("AAAA")
s_static("\r\n")

s_initialize("xmkd")
s_static("XMKD")
s_delim(" ")
s_string("AAAA")
s_static("\r\n")

s_initialize("xrmd")
s_static("XRMD")
s_delim(" ")
s_string("AAAA")
s_static("\r\n")


print "Mutations: " + str(s_num_mutations())

#print "Press CTRL/C to cancel in ",
#for i in range(3):
#   print str(3 - i) + " ",
#   sys.stdout.flush()
#   time.sleep(1)

def receive_ftp_banner(sock):
    sock.recv(1024)

print "Instantiating session"
sess = sessions.Session(sleep_time=0.25, check_data_received_each_request=False)

print "Instantiating target"
target = sessions.Target(SocketConnection("127.0.0.1", 21, proto='tcp'))
target.procmon = pedrpc.Client("127.0.0.1", 26002)

target.procmon_options =  {
    "proc_name" : "ftps.exe",
    "stop_commands" : ['taskkill /IM ftps.exe /F'],
    "start_commands" : ['C:\\work\\ftps.exe'],
}

sess.pre_send = receive_ftp_banner #grab the banner
sess.add_target(target)

sess.connect(s_get("user")) # Notice our commands from the previous file
sess.connect(s_get("user"),s_get("pass"))

# fuzz cases
sess.connect(s_get("pass"),s_get("cwd"))
sess.connect(s_get("pass"),s_get("dele"))
sess.connect(s_get("pass"),s_get("port"))
sess.connect(s_get("pass"),s_get("retr"))
sess.connect(s_get("pass"),s_get("stor"))
sess.connect(s_get("pass"),s_get("xmkd"))
sess.connect(s_get("pass"),s_get("xrmd"))

print "Starting fuzzing now"
sess.fuzz()
```

<!-- Reviewable:start -->
---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jtpereyda/boofuzz/93)

<!-- Reviewable:end -->
