### PR TITLE
Udp broadcast

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,8 @@ Features
 --------
 -  Added ``Request.original_value()`` function to render the request as if it were not fuzzed.
    This will help enable reuse of a fuzz definition to generate valid requests.
+-  ``SocketConnection`` can now send and receive UDP broadcast packets using the ``udp_broadcast`` constructor
+   parameter.
 
 0.0.5
 =====

--- a/setup.py
+++ b/setup.py
@@ -35,7 +35,8 @@ setup(
             'future', 'pyserial', 'pydot2==1.0.33', 'tornado==4.0.2',
             'Flask==0.10.1', 'impacket'],
         extras_require={
-            'dev': ['check-manifest', 'mock', 'pytest', 'pytest-bdd'],
+            # This list is duplicated in tox.ini. Make sure to change both!
+            'dev': ['check-manifest', 'mock', 'pytest', 'pytest-bdd', 'netifaces', 'ipaddress'],
         },
         classifiers=[
             'Development Status :: 4 - Beta',

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,8 @@ deps =
     pytest-bdd
     mock
     check-manifest
+    netifaces
+    ipaddress
 install_command =
     python -m pip install {opts} {packages}
 commands =


### PR DESCRIPTION
Add `SocketConnection` support for UDP broadcast. Includes unit test.

The unit test depends on the test system having an available non-loopback IPv4 address. Hopefully a safe assumption in 2016, maybe not in the futuristic world of IPv6.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jtpereyda/boofuzz/94)
<!-- Reviewable:end -->
