### PR TITLE
Fix excess packages

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Fixes
    but the maximum value may be too high for systems that set it lower than the maximum possible value, 65507.
 -  ``SocketConnection`` class now handles more send and receive errors:  ``ECONNABORTED``, ``ECONNRESET``,
    ``ENETRESET``, and ``ETIMEDOUT``.
+-  Fixed setup.py to not include superfluous packages.
 
 Development
 -----------

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(
         maintainer_email='joshua.t.pereyda@gmail.com',
         url='https://github.com/jtpereyda/boofuzz',
         license='GPL',
-        packages=find_packages(exclude=['unit_tests']),
+        packages=find_packages(exclude=['unit_tests', 'requests', 'examples', 'utils', 'web', 'new_examples']),
         package_data={'boofuzz': ['web/templates/*', 'web/static/css/*']},
         install_requires=[
             'future', 'pyserial', 'pydot2==1.0.33', 'tornado==4.0.2',


### PR DESCRIPTION
Fix setup.py to not include superfluous packages. Regression occurred at 81e5d61bbcdf1cb6ade20f595a670aa84759afd5, Pull Request #43.

This is a really lame error, as it will obscure a user's installed `requests` package. Unfortunately, IMO, the Python packaging system makes this slip-up kind of easy. Oh well.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jtpereyda/boofuzz/104)
<!-- Reviewable:end -->
