### PR TITLE
Upgrade to newer version of pydot to avoid import error message

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         packages=find_packages(exclude=['unit_tests', 'requests', 'examples', 'utils', 'web', 'new_examples']),
         package_data={'boofuzz': ['web/templates/*', 'web/static/css/*']},
         install_requires=[
-            'future', 'pyserial', 'pydot2==1.0.33', 'tornado==4.0.2',
+            'future', 'pyserial', 'pydot==1.2.3', 'tornado==4.0.2',
             'Flask==0.10.1', 'impacket'],
         extras_require={
             # This list is duplicated in tox.ini. Make sure to change both!

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
         packages=find_packages(exclude=['unit_tests', 'requests', 'examples', 'utils', 'web', 'new_examples']),
         package_data={'boofuzz': ['web/templates/*', 'web/static/css/*']},
         install_requires=[
-            'future', 'pyserial', 'pydot==1.2.3', 'tornado==4.0.2',
+            'future', 'pyserial', 'pydot', 'tornado==4.0.2',
             'Flask==0.10.1', 'impacket'],
         extras_require={
             # This list is duplicated in tox.ini. Make sure to change both!


### PR DESCRIPTION
This patch removes the temporary pydot2 dependency and replaces it with a newer pydot release with support for pyparsing > 1.5.7. pydot2 1.0.33 gives the following error when imported from a new boofuzz install.

```
$ pip install boofuzz
Collecting boofuzz
... snip ...
Successfully installed Flask-0.10.1 Jinja2-2.9.5 MarkupSafe-0.23 Werkzeug-0.11.15 backports.ssl-match-hostname-3.5.0.1 boofuzz-0.0.6 certifi-2017.1.23 future-0.16.0 impacket-0.9.15 itsdangerous-0.24 pydot2-1.0.33 pyserial-3.2.1 tornado-4.0.2

$ pip freeze | egrep 'pydot|pypars'
pydot2==1.0.33
pyparsing==2.1.10

$ python -c 'import pydot'
Couldn't import dot_parser, loading of dot files will not be possible.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jtpereyda/boofuzz/119)
<!-- Reviewable:end -->
