### PR TITLE
Add with statement support to blocks

### DIFF
--- a/boofuzz/__init__.py
+++ b/boofuzz/__init__.py
@@ -152,11 +152,14 @@ def s_block(name, group=None, encoder=None, dep=None, dep_value=None, dep_values
     @param dep_compare: (Optional, def="==") Comparison method to use on dependency (==, !=, >, >=, <, <=)
     """
     class ScopedBlock(Block):
+        def __init__(self, block):
+            self.block = block
+
         def __enter__(self):
             """
             Setup before entering the "with" statement body
             """
-            return self
+            return self.block
 
         def __exit__(self, type, value, traceback):
             """
@@ -165,10 +168,9 @@ def s_block(name, group=None, encoder=None, dep=None, dep_value=None, dep_values
             # Automagically close the block when exiting the "with" statement
             s_block_end()
 
-    block = ScopedBlock(name, blocks.CURRENT, group, encoder, dep, dep_value, dep_values, dep_compare)
-    blocks.CURRENT.push(block)
+    block = s_block_start(name, group, encoder, dep, dep_value, dep_values, dep_compare)
 
-    return block
+    return ScopedBlock(block)
 
 def s_block_start(name, *args, **kwargs):
     """
@@ -181,9 +183,13 @@ def s_block_start(name, *args, **kwargs):
                 ...
         s_block_close()
 
+    @note Prefer using s_block to this function directly
     @see s_block
     """
-    return s_block(name, *args, **kwargs)
+    block = Block(name, blocks.CURRENT, *args, **kwargs)
+    blocks.CURRENT.push(block)
+
+    return block
 
 
 # noinspection PyUnusedLocal

--- a/unit_tests/blocks.py
+++ b/unit_tests/blocks.py
@@ -6,6 +6,7 @@ def run():
     dependencies()
     repeaters()
     return_current_mutant()
+    with_statements()
 
     # clear out the requests.
     blocks.REQUESTS = {}
@@ -176,3 +177,14 @@ def return_current_mutant():
         req1.mutate()
     assert (req1.mutant.name == "uhntiss")
     req1.reset()
+
+def with_statements():
+    s_initialize("WITH TEST")
+
+    with s_block("BLOCK1") as b:
+        assert (b.name == "BLOCK1")
+        s_static("test")
+
+    req = s_get("WITH TEST")
+    assert (req.num_mutations() == 0)
+    assert (req.render() == "test")


### PR DESCRIPTION
Added support for automatically scoping blocks using Python's `with` statement. For example what used to be written like this:
```
if s_block_start("myblock"):
    s_string("foobar")
    ...
s_block_end()
```
Can now be simplified to this:
```
with s_block("myblock"):
    s_string("foobar")
    ...
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jtpereyda/boofuzz/121)
<!-- Reviewable:end -->
