### PR TITLE
Fix return dummy value in custom checksum (issue #107)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Features
 
 Fixes
 -----
+-  Fixed: add a dummy value custom checksum in checksum helper (issue #107)
 
 0.0.8
 =====

--- a/boofuzz/blocks/checksum.py
+++ b/boofuzz/blocks/checksum.py
@@ -122,6 +122,8 @@ class Checksum(primitives.BasePrimitive):
         return self._fuzzable and (self._mutant_index != 0) and not self._fuzz_complete
 
     def _get_dummy_value(self):
+        if self._length:
+            return self._length * '\x00'
         return self.checksum_lengths[self._algorithm] * '\x00'
 
     @_may_recurse


### PR DESCRIPTION
When a custom checksum is used like in Issue #107, dummy value is not returned correctly because it always search in checksums_lenghts dictionary but custom function cannot be here.
I fix this error using length value to generate the dummy value.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jtpereyda/boofuzz/149)
<!-- Reviewable:end -->
