### PR TITLE
Add new s_fuzz_list primitive to read fuzz value from files

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@ Upcoming
 Features
 --------
 -  `s_size` is now fuzzable by default.
+-  Add new s_fuzz_list primitive to read fuzz value from files.
 
 Fixes
 -----

--- a/boofuzz/__init__.py
+++ b/boofuzz/__init__.py
@@ -489,7 +489,7 @@ def s_string(value, size=-1, padding="\x00", encoding="ascii", fuzzable=True, ma
 
 def s_from_file(value, size=-1, padding="\x00", encoding="ascii", fuzzable=True, max_len=0, name=None, filename=None):
     """
-    Push a string onto the current block stack.
+    Push a value from file onto the current block stack.
 
     @type  value:    str
     @param value:    Default string value

--- a/boofuzz/__init__.py
+++ b/boofuzz/__init__.py
@@ -23,7 +23,7 @@ from .ifuzz_logger_backend import IFuzzLoggerBackend
 from .itarget_connection import ITargetConnection
 from .primitives import (BasePrimitive, Delim, Group,
                          RandomData, Static, String, BitField,
-                         Byte, Word, DWord, QWord, FuzzList)
+                         Byte, Word, DWord, QWord, FromFile)
 from .serial_connection import SerialConnection
 from .sessions import Session, Target
 from .sex import SullyRuntimeError, SizerNotUtilizedError, MustImplementException
@@ -487,7 +487,7 @@ def s_string(value, size=-1, padding="\x00", encoding="ascii", fuzzable=True, ma
     s = primitives.String(value, size, padding, encoding, fuzzable, max_len, name)
     blocks.CURRENT.push(s)
 
-def s_fuzz_list(value, size=-1, padding="\x00", encoding="ascii", fuzzable=True, max_len=0, name=None, filename=None):
+def s_from_file(value, size=-1, padding="\x00", encoding="ascii", fuzzable=True, max_len=0, name=None, filename=None):
     """
     Push a string onto the current block stack.
 
@@ -509,7 +509,7 @@ def s_fuzz_list(value, size=-1, padding="\x00", encoding="ascii", fuzzable=True,
     @param filename: (Mandatory) Specify filename where to read fuzz list
     """
 
-    s = primitives.FuzzList(value, size, padding, encoding, fuzzable, max_len, name, filename)
+    s = primitives.FromFile(value, size, padding, encoding, fuzzable, max_len, name, filename)
     blocks.CURRENT.push(s)
 
 # noinspection PyTypeChecker

--- a/boofuzz/__init__.py
+++ b/boofuzz/__init__.py
@@ -487,16 +487,12 @@ def s_string(value, size=-1, padding="\x00", encoding="ascii", fuzzable=True, ma
     s = primitives.String(value, size, padding, encoding, fuzzable, max_len, name)
     blocks.CURRENT.push(s)
 
-def s_from_file(value, size=-1, padding="\x00", encoding="ascii", fuzzable=True, max_len=0, name=None, filename=None):
+def s_from_file(value, encoding="ascii", fuzzable=True, max_len=0, name=None, filename=None):
     """
     Push a value from file onto the current block stack.
 
     @type  value:    str
     @param value:    Default string value
-    @type  size:     int
-    @param size:     (Optional, def=-1) Static size of this field, leave -1 for dynamic.
-    @type  padding:  Character
-    @param padding:  (Optional, def="\\x00") Value to use as padding to fill static field size.
     @type  encoding: str
     @param encoding: (Optonal, def="ascii") String encoding, ex: utf_16_le for Microsoft Unicode.
     @type  fuzzable: bool
@@ -509,7 +505,7 @@ def s_from_file(value, size=-1, padding="\x00", encoding="ascii", fuzzable=True,
     @param filename: (Mandatory) Specify filename where to read fuzz list
     """
 
-    s = primitives.FromFile(value, size, padding, encoding, fuzzable, max_len, name, filename)
+    s = primitives.FromFile(value, encoding, fuzzable, max_len, name, filename)
     blocks.CURRENT.push(s)
 
 # noinspection PyTypeChecker

--- a/boofuzz/__init__.py
+++ b/boofuzz/__init__.py
@@ -23,7 +23,7 @@ from .ifuzz_logger_backend import IFuzzLoggerBackend
 from .itarget_connection import ITargetConnection
 from .primitives import (BasePrimitive, Delim, Group,
                          RandomData, Static, String, BitField,
-                         Byte, Word, DWord, QWord)
+                         Byte, Word, DWord, QWord, FuzzList)
 from .serial_connection import SerialConnection
 from .sessions import Session, Target
 from .sex import SullyRuntimeError, SizerNotUtilizedError, MustImplementException
@@ -487,6 +487,30 @@ def s_string(value, size=-1, padding="\x00", encoding="ascii", fuzzable=True, ma
     s = primitives.String(value, size, padding, encoding, fuzzable, max_len, name)
     blocks.CURRENT.push(s)
 
+def s_fuzz_list(value, size=-1, padding="\x00", encoding="ascii", fuzzable=True, max_len=0, name=None, filename=None):
+    """
+    Push a string onto the current block stack.
+
+    @type  value:    str
+    @param value:    Default string value
+    @type  size:     int
+    @param size:     (Optional, def=-1) Static size of this field, leave -1 for dynamic.
+    @type  padding:  Character
+    @param padding:  (Optional, def="\\x00") Value to use as padding to fill static field size.
+    @type  encoding: str
+    @param encoding: (Optonal, def="ascii") String encoding, ex: utf_16_le for Microsoft Unicode.
+    @type  fuzzable: bool
+    @param fuzzable: (Optional, def=True) Enable/disable fuzzing of this primitive
+    @type  max_len:  int
+    @param max_len:  (Optional, def=0) Maximum string length
+    @type  name:     str
+    @param name:     (Optional, def=None) Specifying a name gives you direct access to a primitive
+    @type  filename: str
+    @param filename: (Mandatory) Specify filename where to read fuzz list
+    """
+
+    s = primitives.FuzzList(value, size, padding, encoding, fuzzable, max_len, name, filename)
+    blocks.CURRENT.push(s)
 
 # noinspection PyTypeChecker
 def s_bit_field(value, width, endian=LITTLE_ENDIAN, output_format="binary", signed=False, full_range=False,

--- a/boofuzz/primitives/__init__.py
+++ b/boofuzz/primitives/__init__.py
@@ -4,6 +4,7 @@ from .bit_field import BitField
 from .byte import Byte
 from .delim import Delim
 from .dword import DWord
+from .fuzz_list import FuzzList
 from .group import Group
 from .qword import QWord
 from .random_data import RandomData

--- a/boofuzz/primitives/__init__.py
+++ b/boofuzz/primitives/__init__.py
@@ -4,7 +4,7 @@ from .bit_field import BitField
 from .byte import Byte
 from .delim import Delim
 from .dword import DWord
-from .fuzz_list import FuzzList
+from .from_file import FromFile
 from .group import Group
 from .qword import QWord
 from .random_data import RandomData

--- a/boofuzz/primitives/from_file.py
+++ b/boofuzz/primitives/from_file.py
@@ -5,20 +5,14 @@ from .base_primitive import BasePrimitive
 
 
 class FromFile(BasePrimitive):
-    # store fuzz_library as a class variable to avoid copying the ~70MB structure across each instantiated primitive.
-    _fuzz_library = []
 
-    def __init__(self, value, size=-1, padding="\x00", encoding="ascii", fuzzable=True, max_len=0, name=None, filename=None):
+    def __init__(self, value, encoding="ascii", fuzzable=True, max_len=0, name=None, filename=None):
         """
-        Primitive that cycles through a list of "bad" values from a file. The primitive take filename and open the file to read
-        the values to use in fuzzing process.
+        Cycles through a list of "bad" values from a file(s). Takes filename and open the file(s) to read
+        the values to use in fuzzing process. filename may contain glob characters.
 
         @type  value:    str
         @param value:    Default string value
-        @type  size:     int
-        @param size:     (Optional, def=-1) Static size of this field, leave -1 for dynamic.
-        @type  padding:  chr
-        @param padding:  (Optional, def="\\x00") Value to use as padding to fill static field size.
         @type  encoding: str
         @param encoding: (Optional, def="ascii") String encoding, ex: utf_16_le for Microsoft Unicode.
         @type  fuzzable: bool
@@ -34,92 +28,23 @@ class FromFile(BasePrimitive):
         super(FromFile, self).__init__()
 
         self._value = self._original_value = value
-        self.size = size
-        self.padding = padding
         self.encoding = encoding
         self._fuzzable = fuzzable
         self._name = name
         self._filename = filename
-        self.this_library = []
+        self._fuzz_library = []
         list_of_files = glob.glob(self._filename)
         for fname in list_of_files:
-            _file_handle = open(fname,"r")
-            self.this_library.append(_file_handle.readlines())
-            _file_handle.close()
-
+            with open(fname,"r") as _file_handle:
+                self._fuzz_library.extend(_file_handle.readlines())
+            
         # TODO: Make this more clear
         if max_len > 0:
             # If any of our strings are over max_len
-            if any(len(s) > max_len for s in self.this_library):
+            if any(len(s) > max_len for s in self._fuzz_library):
                 # Pull out only the ones that aren't
-                self.this_library = list(set([s[:max_len] for s in self.this_library]))
+                self._fuzz_library = list(set([s for s in self._fuzz_library if len(s) <= max_len]))
 
     @property
     def name(self):
         return self._name
-
-    
-    def mutate(self):
-        """
-        Mutate the primitive by stepping through the "this" library, return False on
-        completion.
-
-        @rtype:  bool
-        @return: True on success, False otherwise.
-        """
-
-        # loop through the fuzz library until a suitable match is found.
-        while 1:
-            # if we've ran out of mutations, raise the completion flag.
-            if self._mutant_index == self.num_mutations():
-                self._fuzz_complete = True
-
-            # if fuzzing was disabled or complete, and mutate() is called, ensure the original value is restored.
-            if not self._fuzzable or self._fuzz_complete:
-                self._value = self._original_value
-                return False
-
-            # update the current value from the fuzz library.
-            self._value = (self.this_library)[self._mutant_index]
-
-            # increment the mutation count.
-            self._mutant_index += 1
-
-            # if the size parameter is disabled, break out of the loop right now.
-            if self.size == -1:
-                break
-
-            # ignore library items greater then user-supplied length.
-            # TODO: might want to make this smarter.
-            if len(self._value) > self.size:
-                continue
-
-            # pad undersized library items.
-            if len(self._value) < self.size:
-                self._value += self.padding * (self.size - len(self._value))
-                break
-
-        return True
-
-    def num_mutations(self):
-        """
-        Calculate and return the total number of mutations for this individual primitive.
-
-        @rtype:  int
-        @return: Number of mutated forms this primitive can take
-        """
-        return len(self.this_library)
-
-    def _render(self, value):
-        """Render string value, properly encoded.
-        """
-        try:
-            # Note: In the future, we should use unicode strings when we mean to encode them later. As it is, we need
-            # decode the value before decoding it! Meaning we'll never be able to use characters outside the ASCII
-            # range.
-            _rendered = str(value).decode('ascii').encode(self.encoding)
-        except UnicodeDecodeError:
-            # If we can't decode the string, just treat it like a plain byte string
-            _rendered = value
-
-        return _rendered.rstrip()

--- a/boofuzz/primitives/from_file.py
+++ b/boofuzz/primitives/from_file.py
@@ -4,7 +4,7 @@ import glob
 from .base_primitive import BasePrimitive
 
 
-class FuzzList(BasePrimitive):
+class FromFile(BasePrimitive):
     # store fuzz_library as a class variable to avoid copying the ~70MB structure across each instantiated primitive.
     _fuzz_library = []
 
@@ -31,7 +31,7 @@ class FuzzList(BasePrimitive):
         @param filename: Filename pattern to load all fuzz value
         """
 
-        super(FuzzList, self).__init__()
+        super(FromFile, self).__init__()
 
         self._value = self._original_value = value
         self.size = size

--- a/boofuzz/primitives/fuzz_list.py
+++ b/boofuzz/primitives/fuzz_list.py
@@ -1,0 +1,125 @@
+import random
+import glob
+
+from .base_primitive import BasePrimitive
+
+
+class FuzzList(BasePrimitive):
+    # store fuzz_library as a class variable to avoid copying the ~70MB structure across each instantiated primitive.
+    _fuzz_library = []
+
+    def __init__(self, value, size=-1, padding="\x00", encoding="ascii", fuzzable=True, max_len=0, name=None, filename=None):
+        """
+        Primitive that cycles through a list of "bad" values from a file. The primitive take filename and open the file to read
+        the values to use in fuzzing process.
+
+        @type  value:    str
+        @param value:    Default string value
+        @type  size:     int
+        @param size:     (Optional, def=-1) Static size of this field, leave -1 for dynamic.
+        @type  padding:  chr
+        @param padding:  (Optional, def="\\x00") Value to use as padding to fill static field size.
+        @type  encoding: str
+        @param encoding: (Optional, def="ascii") String encoding, ex: utf_16_le for Microsoft Unicode.
+        @type  fuzzable: bool
+        @param fuzzable: (Optional, def=True) Enable/disable fuzzing of this primitive
+        @type  max_len:  int
+        @param max_len:  (Optional, def=0) Maximum string length
+        @type  name:     str
+        @param name:     (Optional, def=None) Specifying a name gives you direct access to a primitive
+        @type  filename: str
+        @param filename: Filename pattern to load all fuzz value
+        """
+
+        super(FuzzList, self).__init__()
+
+        self._value = self._original_value = value
+        self.size = size
+        self.padding = padding
+        self.encoding = encoding
+        self._fuzzable = fuzzable
+        self._name = name
+        self._filename = filename
+        self.this_library = []
+        list_of_files = glob.glob(self._filename)
+        for fname in list_of_files:
+            _file_handle = open(fname,"r")
+            self.this_library.append(_file_handle.readlines())
+            _file_handle.close()
+
+        # TODO: Make this more clear
+        if max_len > 0:
+            # If any of our strings are over max_len
+            if any(len(s) > max_len for s in self.this_library):
+                # Pull out only the ones that aren't
+                self.this_library = list(set([s[:max_len] for s in self.this_library]))
+
+    @property
+    def name(self):
+        return self._name
+
+    
+    def mutate(self):
+        """
+        Mutate the primitive by stepping through the "this" library, return False on
+        completion.
+
+        @rtype:  bool
+        @return: True on success, False otherwise.
+        """
+
+        # loop through the fuzz library until a suitable match is found.
+        while 1:
+            # if we've ran out of mutations, raise the completion flag.
+            if self._mutant_index == self.num_mutations():
+                self._fuzz_complete = True
+
+            # if fuzzing was disabled or complete, and mutate() is called, ensure the original value is restored.
+            if not self._fuzzable or self._fuzz_complete:
+                self._value = self._original_value
+                return False
+
+            # update the current value from the fuzz library.
+            self._value = (self.this_library)[self._mutant_index]
+
+            # increment the mutation count.
+            self._mutant_index += 1
+
+            # if the size parameter is disabled, break out of the loop right now.
+            if self.size == -1:
+                break
+
+            # ignore library items greater then user-supplied length.
+            # TODO: might want to make this smarter.
+            if len(self._value) > self.size:
+                continue
+
+            # pad undersized library items.
+            if len(self._value) < self.size:
+                self._value += self.padding * (self.size - len(self._value))
+                break
+
+        return True
+
+    def num_mutations(self):
+        """
+        Calculate and return the total number of mutations for this individual primitive.
+
+        @rtype:  int
+        @return: Number of mutated forms this primitive can take
+        """
+        return len(self.this_library)
+
+    def _render(self, value):
+        """Render string value, properly encoded.
+        """
+        try:
+            # Note: In the future, we should use unicode strings when we mean to encode them later. As it is, we need
+            # decode the value before decoding it! Meaning we'll never be able to use characters outside the ASCII
+            # range.
+            _rendered = str(value).decode('ascii').encode(self.encoding)
+        except UnicodeDecodeError:
+            # If we can't decode the string, just treat it like a plain byte string
+            _rendered = value
+
+        return _rendered.rstrip()


### PR DESCRIPTION
Now with s_fuzz_list it is possible to add values from files generated by radamsa
By example, I create 3 mutated value of "user" string
```
echo -ne "user" | radamsa -n 3 -o /tmp/fuzzlist%n.rad
```
Now to use them in test cases, I add this primitive in boofuzz model
```
s_fuzz_list("anonymous", filename="/tmp/fuzzlist*.rad")
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/jtpereyda/boofuzz/151)
<!-- Reviewable:end -->
