### PR TITLE
Remove bad link in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -13,7 +13,7 @@ All pull requests are subject to professional code review. If you do not want yo
 Contributors
 ============
 
-See :ref:`install` for instructions on installing boofuzz from source with developer options.
+See installation instructions for details on installing boofuzz from source with developer options.
 
 Pull Request Checklist
 ----------------------


### PR DESCRIPTION
Link presents a problem since this file is incorporated in the docs structure as well. The relative link only works in the Github style view; the Sphinx link only works in the docs view. Solution: just remove the link.