### PR TITLE
Fixed "No such process" error process_monitor_unix

### DIFF
--- a/process_monitor_unix.py
+++ b/process_monitor_unix.py
@@ -89,8 +89,12 @@ class DebuggerThread:
         return self.exit_status
 
     def stop_target(self):
-        os.kill(self.pid, signal.SIGKILL)
-        self.alive = False
+        try:
+            os.kill(self.pid, signal.SIGKILL)
+        except OSError:
+            return False
+        else:
+            self.alive = False
 
     def is_alive(self):
         return self.alive

--- a/process_monitor_unix.py
+++ b/process_monitor_unix.py
@@ -91,8 +91,8 @@ class DebuggerThread:
     def stop_target(self):
         try:
             os.kill(self.pid, signal.SIGKILL)
-        except OSError:
-            return False
+        except OSError as e:
+            print e.errno
         else:
             self.alive = False
 


### PR DESCRIPTION
OSError: [Error 3] No such process thrown on line 91 when restarting a process. Specifically when the process has already crashed due to a fuzzing test case. Added a try-catch statement to see if pid exists.