### PR TITLE
add default_value param for s_group()

### DIFF
--- a/boofuzz/__init__.py
+++ b/boofuzz/__init__.py
@@ -382,19 +382,21 @@ def s_delim(value, fuzzable=True, name=None):
     blocks.CURRENT.push(delim)
 
 
-def s_group(name, values):
+def s_group(name, values, default_value=None):
     """
     This primitive represents a list of static values, stepping through each one on mutation. You can tie a block
     to a group primitive to specify that the block should cycle through all possible mutations for *each* value
     within the group. The group primitive is useful for example for representing a list of valid opcodes.
 
-    :type  name:   str
-    :param name:   Name of group
-    :type  values: List or raw data
-    :param values: List of possible raw values this group can take.
+    :type  name:            str
+    :param name:            Name of group
+    :type  values:          List or raw data
+    :param values:          List of possible raw values this group can take.
+
+    :param default_value:   (Optional, def=None) Specifying a value when fuzzing() is complete
     """
 
-    group = primitives.Group(name, values)
+    group = primitives.Group(name, values, default_value)
     blocks.CURRENT.push(group)
 
 

--- a/boofuzz/primitives/group.py
+++ b/boofuzz/primitives/group.py
@@ -2,16 +2,18 @@ from .base_primitive import BasePrimitive
 
 
 class Group(BasePrimitive):
-    def __init__(self, name, values):
+    def __init__(self, name, values, default_value=None):
         """
         This primitive represents a list of static values, stepping through each one on mutation. You can tie a block
         to a group primitive to specify that the block should cycle through all possible mutations for *each* value
         within the group. The group primitive is useful for example for representing a list of valid opcodes.
 
-        @type  name:   str
-        @param name:   Name of group
-        @type  values: list or str
-        @param values: List of possible raw values this group can take.
+        @type  name:            str
+        @param name:            Name of group
+        @type  values:          list or str
+        @param values:          List of possible raw values this group can take.
+
+        @param default_value:   Specifying a value when fuzzing() is complete
         """
 
         super(Group, self).__init__()
@@ -21,7 +23,9 @@ class Group(BasePrimitive):
 
         assert len(self.values) > 0, "You can't have an empty value list for your group!"
 
-        self._value = self._original_value = self.values[0]
+        if not default_value:
+            default_value = self.values[0]
+        self._value = self._original_value = default_value
 
         for val in self.values:
             assert isinstance(val, basestring), "Value list may only contain strings or raw data"


### PR DESCRIPTION
The default behavior of `s_group()` when fuzzing is complete is to choose `values[0]` as its `original_value`. Sometimes, the same `values` may be used in many places, the `original_value` of which may be different.

The param `default_value` added allows users to specify the value they want. If not specified, `values[0]` is used instead, same as the default behaviour.