### PR TITLE
add s_mirror(), used to keep updated with other elements

### DIFF
--- a/boofuzz/__init__.py
+++ b/boofuzz/__init__.py
@@ -23,7 +23,7 @@ from .ifuzz_logger_backend import IFuzzLoggerBackend
 from .itarget_connection import ITargetConnection
 from .primitives import (BasePrimitive, Delim, Group,
                          RandomData, Static, String, BitField,
-                         Byte, Word, DWord, QWord, FromFile)
+                         Byte, Word, DWord, QWord, FromFile, Mirror)
 from .serial_connection import SerialConnection
 from .sessions import Session, Target, open_test_run
 from .exception import SullyRuntimeError, SizerNotUtilizedError, MustImplementException
@@ -465,6 +465,22 @@ def s_static(value, name=None):
 
     static = primitives.Static(value, name)
     blocks.CURRENT.push(static)
+
+
+def s_mirror(primitive_name, name=None):
+    """
+    Push a mirror of another primitive onto the current block stack.
+    
+    :type primitive_name:   str
+    :param primitive_name:  Name of target primitive
+    :type name:             str
+    :param name:            (Optional, def=None) Name of current primitive
+    """
+    if primitive_name not in blocks.CURRENT.names:
+        raise sex.SullyRuntimeError("CAN NOT ADD A MIRROR FOR A NON-EXIST PRIMITIVE CURRENTLY")
+
+    mirror = primitives.Mirror(primitive_name, blocks.CURRENT, name)
+    blocks.CURRENT.push(mirror)
 
 
 def s_string(value, size=-1, padding="\x00", encoding="ascii", fuzzable=True, max_len=0, name=None):

--- a/boofuzz/primitives/__init__.py
+++ b/boofuzz/primitives/__init__.py
@@ -11,3 +11,4 @@ from .random_data import RandomData
 from .static import Static
 from .string import String
 from .word import Word
+from .mirror import Mirror

--- a/boofuzz/primitives/mirror.py
+++ b/boofuzz/primitives/mirror.py
@@ -1,0 +1,60 @@
+from functools import wraps
+from .base_primitive import BasePrimitive
+
+
+def _may_recurse(f):
+    @wraps(f)
+    def safe_recurse(self, *args, **kwargs):
+        self._recursion_flag = True
+        result = f(self, *args, **kwargs)
+        self._recursion_flag = False
+        return result
+
+    return safe_recurse
+
+
+class Mirror(BasePrimitive):
+    """
+    Primitive used to keep updated with another primitive.
+
+    Args:
+        primitive_name (str):   Name of target primitive.
+        request (s_request):    Request this primitive belongs to.
+        name (str, optional):   Name of current primitive. Default None.
+    """
+
+    def __init__(self, primitive_name, request, name=None):
+        super(Mirror, self).__init__()
+
+        self._primitive_name = primitive_name
+        self._request = request
+        self._name = name
+        self._fuzzable = False
+
+        # Set the recursion flag before calling a method that may cause a recursive loop.
+        self._recursion_flag = False
+
+    @property
+    def name(self):
+        return self._name
+
+    def render(self):
+        """
+        Render the mirror.
+
+        :return: Rendered value.
+        """
+        self._rendered = self._render_primitive(self._primitive_name)
+        return self._rendered
+    
+    @property
+    def original_value(self):
+        return self._original_value_of_primitive(self._primitive_name)
+
+    @_may_recurse
+    def _render_primitive(self, primitive_name):
+        return self._request.names[primitive_name].render() if primitive_name is not None else None
+    
+    @_may_recurse
+    def _original_value_of_primitive(self, primitive_name):
+        return self._request.names[primitive_name].original_value if primitive_name is not None else None

--- a/unit_tests/primitives.py
+++ b/unit_tests/primitives.py
@@ -4,6 +4,7 @@ from boofuzz import *
 def run():
     signed_tests()
     string_tests()
+    s_mirror_tests()
     # fuzz_extension_tests()
 
     # clear out the requests.
@@ -65,6 +66,23 @@ def string_tests():
     for i in xrange(0, 50):
         s_mutate()
         assert (len(req.names["sized_string"].render()) == 200)
+
+
+def s_mirror_tests():
+    TEST_GROUP_VALUES = ['aaa', 'bbb', 'ccc', 'ddd']
+    s_initialize('test_s_mirror')
+    s_static('<')
+    s_group('group_start', values=TEST_GROUP_VALUES)
+    s_static('>')
+    s_static('hello')
+    s_static('<')
+    s_mirror('group_start', name='group_end')
+    s_static('/>')
+
+    req = s_get('test_s_mirror')
+    for _ in xrange(len(TEST_GROUP_VALUES)):
+        s_mutate()
+        assert (req.names['group_end'].render() == req.names['group_start'].render())
 
 
 def fuzz_extension_tests():


### PR DESCRIPTION
As discussed in [Issue #226](https://github.com/jtpereyda/boofuzz/issues/226#issue-382093545), a new primitive `s_mirror()` is added, which is used to keep updated with other elements. Also, a simple testcase has been given in `unit_tests/primitives.py`. 

Any suggestions? Thanks.