### PR TITLE
Fix db_logger write

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,9 @@
+Upcoming
+======
+Features
+--------
+- New Session option `fuzz_db_keep_only_n_pass_cases`. This allowes saving only n test cases preceding a failure or error to the database.
+
 v0.1.3
 ======
 Features

--- a/boofuzz/fuzz_logger.py
+++ b/boofuzz/fuzz_logger.py
@@ -70,6 +70,14 @@ class FuzzLogger(IFuzzLogger):
         for fuzz_logger in self._fuzz_loggers:
             fuzz_logger.log_send(data=data)
 
+    def end_test_case(self):
+        for fuzz_logger in self._fuzz_loggers:
+            fuzz_logger.end_test_case()
+
+    def end_test(self):
+        for fuzz_logger in self._fuzz_loggers:
+            fuzz_logger.end_test()
+
     def failure_summary(self):
         """Return test summary string based on fuzz logger results.
 
@@ -87,6 +95,3 @@ class FuzzLogger(IFuzzLogger):
             summary += "{0}".format('\n'.join(map(str, self.error_test_cases.iterkeys())))
 
         return summary
-
-    def write_log(self, force=False):
-        self._fuzz_loggers[0].write_log(force=force)

--- a/boofuzz/fuzz_logger.py
+++ b/boofuzz/fuzz_logger.py
@@ -70,13 +70,13 @@ class FuzzLogger(IFuzzLogger):
         for fuzz_logger in self._fuzz_loggers:
             fuzz_logger.log_send(data=data)
 
-    def end_test_case(self):
+    def close_test_case(self):
         for fuzz_logger in self._fuzz_loggers:
-            fuzz_logger.end_test_case()
+            fuzz_logger.close_test_case()
 
-    def end_test(self):
+    def close_test(self):
         for fuzz_logger in self._fuzz_loggers:
-            fuzz_logger.end_test()
+            fuzz_logger.close_test()
 
     def failure_summary(self):
         """Return test summary string based on fuzz logger results.

--- a/boofuzz/fuzz_logger.py
+++ b/boofuzz/fuzz_logger.py
@@ -87,3 +87,6 @@ class FuzzLogger(IFuzzLogger):
             summary += "{0}".format('\n'.join(map(str, self.error_test_cases.iterkeys())))
 
         return summary
+
+    def write_log(self, force=False):
+        self._fuzz_loggers[0].write_log(force=force)

--- a/boofuzz/fuzz_logger_csv.py
+++ b/boofuzz/fuzz_logger_csv.py
@@ -36,7 +36,7 @@ class FuzzLoggerCsv(ifuzz_logger_backend.IFuzzLoggerBackend):
     def __init__(self, file_handle=sys.stdout, bytes_to_str=DEFAULT_HEX_TO_STR):
         """
         Args:
-            file_hanlde (io.TextIOBase): Open file handle for logging. Defaults to sys.stdout.
+            file_handle (io.TextIOBase): Open file handle for logging. Defaults to sys.stdout.
             bytes_to_str (function): Function that converts sent/received bytes data to string for logging.
         """
         self._file_handle = file_handle
@@ -69,6 +69,12 @@ class FuzzLoggerCsv(ifuzz_logger_backend.IFuzzLoggerBackend):
 
     def log_pass(self, description=""):
         self._print_log_msg(["pass", "", "", description])
+
+    def end_test_case(self):
+        pass
+
+    def end_test(self):
+        pass
 
     def _print_log_msg(self, msg):
         time_stamp = get_time_stamp()

--- a/boofuzz/fuzz_logger_csv.py
+++ b/boofuzz/fuzz_logger_csv.py
@@ -70,10 +70,10 @@ class FuzzLoggerCsv(ifuzz_logger_backend.IFuzzLoggerBackend):
     def log_pass(self, description=""):
         self._print_log_msg(["pass", "", "", description])
 
-    def end_test_case(self):
+    def close_test_case(self):
         pass
 
-    def end_test(self):
+    def close_test(self):
         pass
 
     def _print_log_msg(self, msg):

--- a/boofuzz/fuzz_logger_db.py
+++ b/boofuzz/fuzz_logger_db.py
@@ -3,7 +3,7 @@ import collections
 import datetime
 import sqlite3
 
-from . import constants
+#from . import constants
 from . import helpers
 from . import ifuzz_logger_backend
 from . import data_test_case
@@ -21,7 +21,6 @@ def hex_to_hexstr(input_bytes):
     """
     return helpers.hex_str(input_bytes)
 
-
 DEFAULT_HEX_TO_STR = hex_to_hexstr
 
 
@@ -33,7 +32,7 @@ def get_time_stamp():
 class FuzzLoggerDb(ifuzz_logger_backend.IFuzzLoggerBackend):
     """Log fuzz data in a sqlite database file."""
 
-    def __init__(self, db_filename):
+    def __init__(self, db_filename, num_log_cases=0):
         self._database_connection = sqlite3.connect(db_filename, check_same_thread=False)
         self._db_cursor = self._database_connection.cursor()
         self._db_cursor.execute('''CREATE TABLE cases (name text, number integer, timestamp TEXT)''')
@@ -41,6 +40,11 @@ class FuzzLoggerDb(ifuzz_logger_backend.IFuzzLoggerBackend):
             '''CREATE TABLE steps (test_case_index integer, type text, description text, data blob, timestamp TEXT)''')
 
         self._current_test_case_index = None
+
+        self._queue = collections.deque([])  # Queue that holds last n test cases before commiting
+        self._queue_max_len = num_log_cases
+        self._fail_detected = False
+        self._log_first_case = True
 
     def get_test_case_data(self, index):
         c = self._database_connection.cursor()
@@ -67,49 +71,60 @@ class FuzzLoggerDb(ifuzz_logger_backend.IFuzzLoggerBackend):
                                            steps=steps)
 
     def open_test_case(self, test_case_id, name, index, *args, **kwargs):
-        self._db_cursor.execute('''INSERT INTO cases VALUES(?, ?, ?)''', [name, index, helpers.get_time_stamp()])
+        self._queue.append(["INSERT INTO cases VALUES(?, ?, ?);\n", name, index, helpers.get_time_stamp()])
         self._current_test_case_index = index
-        self._database_connection.commit()
 
     def open_test_step(self, description):
-        self._db_cursor.execute('''INSERT INTO steps VALUES(?, ?, ?, ?, ?)''',
-                                [self._current_test_case_index, 'step', description, b'', helpers.get_time_stamp()])
-        self._database_connection.commit()
+        self._queue.append(["INSERT INTO steps VALUES(?, ?, ?, ?, ?);\n",
+            self._current_test_case_index, 'step', description, b'', helpers.get_time_stamp()])
 
     def log_check(self, description):
-        self._db_cursor.execute('''INSERT INTO steps VALUES(?, ?, ?, ?, ?)''',
-                                [self._current_test_case_index, 'check', description, b'', helpers.get_time_stamp()])
-        self._database_connection.commit()
+        self._queue.append(["INSERT INTO steps VALUES(?, ?, ?, ?, ?);\n",
+            self._current_test_case_index, 'check', description, b'', helpers.get_time_stamp()])
 
     def log_error(self, description):
-        self._db_cursor.execute('''INSERT INTO steps VALUES(?, ?, ?, ?, ?)''',
-                                [self._current_test_case_index, 'error', description, b'', helpers.get_time_stamp()])
-        self._database_connection.commit()
+        self._queue.append(["INSERT INTO steps VALUES(?, ?, ?, ?, ?);\n",
+            self._current_test_case_index, 'error', description, b'', helpers.get_time_stamp()])
+        self._fail_detected = True
+        self.write_log()
 
     def log_recv(self, data):
-        self._db_cursor.execute('''INSERT INTO steps VALUES(?, ?, ?, ?, ?)''',
-                                [self._current_test_case_index, 'receive', u'', buffer(data), helpers.get_time_stamp()])
-        self._database_connection.commit()
+        self._queue.append(["INSERT INTO steps VALUES(?, ?, ?, ?, ?);\n",
+            self._current_test_case_index, 'receive', u'', buffer(data), helpers.get_time_stamp()])
 
     def log_send(self, data):
-        self._db_cursor.execute('''INSERT INTO steps VALUES(?, ?, ?, ?, ?)''',
-                                [self._current_test_case_index, 'send', u'', buffer(data), helpers.get_time_stamp()])
-        self._database_connection.commit()
+        self._queue.append(["INSERT INTO steps VALUES(?, ?, ?, ?, ?);\n",
+            self._current_test_case_index, 'send', u'', buffer(data), helpers.get_time_stamp()])
 
     def log_info(self, description):
-        self._db_cursor.execute('''INSERT INTO steps VALUES(?, ?, ?, ?, ?)''',
-                                [self._current_test_case_index, 'info', description, b'', helpers.get_time_stamp()])
-        self._database_connection.commit()
+        self._queue.append(["INSERT INTO steps VALUES(?, ?, ?, ?, ?);\n",
+            self._current_test_case_index, 'info', description, b'', helpers.get_time_stamp()])
 
     def log_fail(self, description=""):
-        self._db_cursor.execute('''INSERT INTO steps VALUES(?, ?, ?, ?, ?)''',
-                                [self._current_test_case_index, 'fail', description, b'', helpers.get_time_stamp()])
-        self._database_connection.commit()
+        self._queue.append(["INSERT INTO steps VALUES(?, ?, ?, ?, ?);\n",
+            self._current_test_case_index, 'fail', description, b'', helpers.get_time_stamp()])
+        self._fail_detected = True
 
     def log_pass(self, description=""):
-        self._db_cursor.execute('''INSERT INTO steps VALUES(?, ?, ?, ?, ?)''',
-                                [self._current_test_case_index, 'pass', description, b'', helpers.get_time_stamp()])
-        self._database_connection.commit()
+        self._queue.append(["INSERT INTO steps VALUES(?, ?, ?, ?, ?);\n",
+            self._current_test_case_index, 'pass', description, b'', helpers.get_time_stamp()])
+
+    def write_log(self, force=False):
+
+        if self._queue_max_len > 0:
+            while (self._current_test_case_index - next(
+                    x for x in self._queue[0] if isinstance(x, (int, long)))) >= self._queue_max_len:
+                self._queue.popleft()
+        else:
+            force=True
+
+        if force or self._fail_detected or self._log_first_case:
+            for i in range(len(self._queue)):
+                self._db_cursor.execute(self._queue[0][0], self._queue[0][1:])
+                self._queue.popleft()
+            self._database_connection.commit()
+            self._log_first_case = False
+            self._fail_detected = False
 
 
 class FuzzLoggerDbReader(object):

--- a/boofuzz/fuzz_logger_db.py
+++ b/boofuzz/fuzz_logger_db.py
@@ -108,10 +108,10 @@ class FuzzLoggerDb(ifuzz_logger_backend.IFuzzLoggerBackend):
         self._queue.append(["INSERT INTO steps VALUES(?, ?, ?, ?, ?);\n",
             self._current_test_case_index, 'pass', description, b'', helpers.get_time_stamp()])
 
-    def end_test_case(self):
+    def close_test_case(self):
         self._write_log(force=False)
 
-    def end_test(self):
+    def close_test(self):
         self._write_log(force=True)
 
     def _write_log(self, force=False):

--- a/boofuzz/fuzz_logger_file.py
+++ b/boofuzz/fuzz_logger_file.py
@@ -30,10 +30,10 @@ class FuzzLoggerFile(ifuzz_logger.IFuzzLogger):
     def log_check(self, description):
         raise Exception("FuzzLoggerFile does not support log_check()!")
 
-    def end_test_case(self):
+    def close_test_case(self):
         pass
 
-    def end_test(self):
+    def close_test(self):
         pass
 
     def __init__(self, path):

--- a/boofuzz/fuzz_logger_file.py
+++ b/boofuzz/fuzz_logger_file.py
@@ -30,6 +30,12 @@ class FuzzLoggerFile(ifuzz_logger.IFuzzLogger):
     def log_check(self, description):
         raise Exception("FuzzLoggerFile does not support log_check()!")
 
+    def end_test_case(self):
+        pass
+
+    def end_test(self):
+        pass
+
     def __init__(self, path):
         """
         :param path: Directory in which to save fuzz data.

--- a/boofuzz/fuzz_logger_text.py
+++ b/boofuzz/fuzz_logger_text.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
 import sys
-from colorama import Fore, Back, Style, init
+from colorama import init #, Fore, Back, Style
 
 from . import helpers
 from . import ifuzz_logger_backend
@@ -48,9 +48,8 @@ class FuzzLoggerText(ifuzz_logger_backend.IFuzzLoggerBackend):
                             msg_type='receive')
 
     def log_send(self, data):
-        self._print_log_msg(
-            data=data,
-            msg_type='send')
+        self._print_log_msg(data=data,
+                            msg_type='send')
 
     def log_info(self, description):
         self._print_log_msg(msg=description,

--- a/boofuzz/fuzz_logger_text.py
+++ b/boofuzz/fuzz_logger_text.py
@@ -1,6 +1,6 @@
 from __future__ import print_function
 import sys
-from colorama import init #, Fore, Back, Style
+from colorama import init
 
 from . import helpers
 from . import ifuzz_logger_backend
@@ -66,6 +66,12 @@ class FuzzLoggerText(ifuzz_logger_backend.IFuzzLoggerBackend):
     def log_pass(self, description=""):
         self._print_log_msg(msg=description,
                             msg_type='pass')
+
+    def end_test_case(self):
+        pass
+
+    def end_test(self):
+        pass
 
     def _print_log_msg(self, msg_type, msg=None, data=None):
         print(helpers.format_log_msg(msg_type=msg_type, description=msg, data=data, indent_size=self.INDENT_SIZE),

--- a/boofuzz/fuzz_logger_text.py
+++ b/boofuzz/fuzz_logger_text.py
@@ -67,10 +67,10 @@ class FuzzLoggerText(ifuzz_logger_backend.IFuzzLoggerBackend):
         self._print_log_msg(msg=description,
                             msg_type='pass')
 
-    def end_test_case(self):
+    def close_test_case(self):
         pass
 
-    def end_test(self):
+    def close_test(self):
         pass
 
     def _print_log_msg(self, msg_type, msg=None, data=None):

--- a/boofuzz/ifuzz_logger.py
+++ b/boofuzz/ifuzz_logger.py
@@ -173,3 +173,31 @@ class IFuzzLogger(object):
         :rtype: None
         """
         raise NotImplementedError
+
+    @abc.abstractmethod
+    def end_test_case(self):
+        """
+        Called after a test case has been completed. Can be used to inform the operator
+        or save the test case log.
+
+        :param None
+        :type None
+
+        :return: None
+        :rtype: None
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def end_test(self):
+        """
+        Called after a test case has been completed. Can be used to inform the operator
+        or save the test log.
+
+        :param None
+        :type None
+
+        :return: None
+        :rtype: None
+        """
+        raise NotImplementedError

--- a/boofuzz/ifuzz_logger.py
+++ b/boofuzz/ifuzz_logger.py
@@ -175,7 +175,7 @@ class IFuzzLogger(object):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def end_test_case(self):
+    def close_test_case(self):
         """
         Called after a test case has been completed. Can be used to inform the operator
         or save the test case log.
@@ -189,9 +189,9 @@ class IFuzzLogger(object):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def end_test(self):
+    def close_test(self):
         """
-        Called after a test case has been completed. Can be used to inform the operator
+        Called after a test has been completed. Can be used to inform the operator
         or save the test log.
 
         :param None

--- a/boofuzz/sessions.py
+++ b/boofuzz/sessions.py
@@ -650,7 +650,7 @@ class Session(pgraph.Graph):
                 self._fuzz_current_case(*fuzz_args)
 
                 num_cases_actually_fuzzed += 1
-            self._fuzz_data_logger.end_test()
+            self._fuzz_data_logger.close_test()
         except KeyboardInterrupt:
             # TODO: should wait for the end of the ongoing test case, and stop gracefully netmon and procmon
             self.export_file()
@@ -1347,7 +1347,7 @@ class Session(pgraph.Graph):
         finally:
             self._process_failures(target=target)
             self._stop_netmon(target=target)
-            self._fuzz_data_logger.end_test_case()
+            self._fuzz_data_logger.close_test_case()
             self.export_file()
 
     def _test_case_name_feature_check(self, path):

--- a/boofuzz/sessions.py
+++ b/boofuzz/sessions.py
@@ -280,6 +280,9 @@ class Session(pgraph.Graph):
         web_port (int):         Port for monitoring fuzzing campaign via a web browser. Default 26000.
         fuzz_data_logger (fuzz_logger.FuzzLogger): DEPRECATED. Use fuzz_loggers instead.
         fuzz_loggers (list of ifuzz_logger.IFuzzLogger): For saving test data and results.. Default Log to STDOUT.
+        fuzz_loggers_keep_num_log_cases (int): Number of most recent test cases to save to db in case of an error or
+                                               failure. Set to 0 to save after every test step (high disk I/O!)
+                                               Default 0
         receive_data_after_each_request (bool): If True, Session will attempt to receive a reply after transmitting
                                                 each non-fuzzed node. Default True.
         check_data_received_each_request (bool): If True, Session will verify that some data has
@@ -313,6 +316,7 @@ class Session(pgraph.Graph):
                  restart_sleep_time=5,
                  fuzz_data_logger=None,
                  fuzz_loggers=None,
+                 fuzz_loggers_keep_num_log_cases=0,
                  receive_data_after_each_request=True,
                  check_data_received_each_request=False,
                  receive_data_after_fuzz=False,
@@ -348,7 +352,8 @@ class Session(pgraph.Graph):
         helpers.mkdir_safe(os.path.join(constants.RESULTS_DIR))
         self._run_id = datetime.datetime.utcnow().replace(microsecond=0).isoformat().replace(':', '-')
         self._db_filename = os.path.join(constants.RESULTS_DIR, 'run-{0}.db'.format(self._run_id))
-        self._db_logger = fuzz_logger_db.FuzzLoggerDb(self._db_filename)
+        self._db_logger = fuzz_logger_db.FuzzLoggerDb(db_filename=self._db_filename,
+                                                      num_log_cases=fuzz_loggers_keep_num_log_cases)
 
         self._fuzz_data_logger = fuzz_logger.FuzzLogger(fuzz_loggers=[self._db_logger] + fuzz_loggers)
         self._check_data_received_each_request = check_data_received_each_request
@@ -643,6 +648,7 @@ class Session(pgraph.Graph):
                 self._fuzz_current_case(*fuzz_args)
 
                 num_cases_actually_fuzzed += 1
+            self._fuzz_data_logger.write_log(force=True)
         except KeyboardInterrupt:
             # TODO: should wait for the end of the ongoing test case, and stop gracefully netmon and procmon
             self.export_file()
@@ -1339,6 +1345,7 @@ class Session(pgraph.Graph):
         finally:
             self._process_failures(target=target)
             self._stop_netmon(target=target)
+            self._fuzz_data_logger.write_log()
             self.export_file()
 
     def _test_case_name_feature_check(self, path):

--- a/boofuzz/sessions.py
+++ b/boofuzz/sessions.py
@@ -280,9 +280,9 @@ class Session(pgraph.Graph):
         web_port (int):         Port for monitoring fuzzing campaign via a web browser. Default 26000.
         fuzz_data_logger (fuzz_logger.FuzzLogger): DEPRECATED. Use fuzz_loggers instead.
         fuzz_loggers (list of ifuzz_logger.IFuzzLogger): For saving test data and results.. Default Log to STDOUT.
-        fuzz_loggers_keep_num_log_cases (int): Number of most recent test cases to save to db in case of an error or
-                                               failure. Set to 0 to save after every test step (high disk I/O!)
-                                               Default 0
+        fuzz_db_keep_only_n_pass_cases (int): Minimize disk usage by only saving passing test cases
+                                              if they are in the n test cases preceding a failure or error.
+                                              Set to 0 to save after every test case (high disk I/O!). Default 0.
         receive_data_after_each_request (bool): If True, Session will attempt to receive a reply after transmitting
                                                 each non-fuzzed node. Default True.
         check_data_received_each_request (bool): If True, Session will verify that some data has
@@ -316,7 +316,7 @@ class Session(pgraph.Graph):
                  restart_sleep_time=5,
                  fuzz_data_logger=None,
                  fuzz_loggers=None,
-                 fuzz_loggers_keep_num_log_cases=0,
+                 fuzz_db_keep_only_n_pass_cases=0,
                  receive_data_after_each_request=True,
                  check_data_received_each_request=False,
                  receive_data_after_fuzz=False,
@@ -353,7 +353,7 @@ class Session(pgraph.Graph):
         self._run_id = datetime.datetime.utcnow().replace(microsecond=0).isoformat().replace(':', '-')
         self._db_filename = os.path.join(constants.RESULTS_DIR, 'run-{0}.db'.format(self._run_id))
         self._db_logger = fuzz_logger_db.FuzzLoggerDb(db_filename=self._db_filename,
-                                                      num_log_cases=fuzz_loggers_keep_num_log_cases)
+                                                      num_log_cases=fuzz_db_keep_only_n_pass_cases)
 
         self._fuzz_data_logger = fuzz_logger.FuzzLogger(fuzz_loggers=[self._db_logger] + fuzz_loggers)
         self._check_data_received_each_request = check_data_received_each_request
@@ -648,7 +648,7 @@ class Session(pgraph.Graph):
                 self._fuzz_current_case(*fuzz_args)
 
                 num_cases_actually_fuzzed += 1
-            self._fuzz_data_logger.write_log(force=True)
+            self._fuzz_data_logger.end_test()
         except KeyboardInterrupt:
             # TODO: should wait for the end of the ongoing test case, and stop gracefully netmon and procmon
             self.export_file()
@@ -1345,7 +1345,7 @@ class Session(pgraph.Graph):
         finally:
             self._process_failures(target=target)
             self._stop_netmon(target=target)
-            self._fuzz_data_logger.write_log()
+            self._fuzz_data_logger.end_test_case()
             self.export_file()
 
     def _test_case_name_feature_check(self, path):


### PR DESCRIPTION
- Db is now only written to disk on test case completion
- Added option to only write the log of the last n test cases to disk when an error or a failure are detected.
  First and last test case are always logged
- Commented out some unused imports according to PyCharm
- Minor formating fix in fuzz_logger_text.py

TODO: Changelog, documentation/comments