### PR TITLE
Fixed setup.py for issue #217

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
         url='https://github.com/jtpereyda/boofuzz',
         license='GPL',
         packages=find_packages(exclude=['unit_tests', 'requests', 'examples', 'utils', 'web', 'new_examples']),
-        package_data={'boofuzz': ['web/templates/*', 'web/static/css/*']},
+        package_data={'boofuzz': ['web/templates/*', 'web/static/css/*', 'web/static/js/*']},
         install_requires=[
             'future', 'pyserial', 'pydot', 'tornado~=4.0',
             'Flask~=1.0', 'impacket', 'colorama', 'attrs', 'click', 'psutil'],


### PR DESCRIPTION
The setup.py for pip installation is missing the package_data path to /web/static/js/.
This should fix issue #217.