### PR TITLE
Fix some warnings when building docs

### DIFF
--- a/docs/source/boofuzz.sex.rst
+++ b/docs/source/boofuzz.sex.rst
@@ -1,7 +1,0 @@
-boofuzz.sex module
-==================
-
-.. automodule:: boofuzz.sex
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/user/logging.rst
+++ b/docs/user/logging.rst
@@ -37,10 +37,7 @@ CSV Logging
 
 File Logging
 ============
-.. autoclass:: boofuzz.FuzzLoggerFile
-    :members:
-    :undoc-members:
-    :show-inheritance:
+Deprecated: Use FuzzLogger with FuzzLoggerText for typical fuzz logging.
 
 FuzzLogger Object
 =================


### PR DESCRIPTION
PR to #240 
- removed `boofuzz/docs/source/boofuzz.sex.rst`
- marked `boofuzz.FuzzLoggerFile` as depreciated

Some warnings that I couldn't fix quickly are still persistent.
```
Running Sphinx v1.6.7
making output directory...
loading pickled environment... not yet created
building [mo]: targets for 0 po files that are out of date
building [html]: targets for 16 source files that are out of date
updating environment: 16 added, 0 changed, 0 removed
reading sources... [100%] user/static-protocol-definition                                                                                                                                                   
/home/papgft/.local/lib/python2.7/site-packages/boofuzz/serial_connection.py:docstring of boofuzz.SerialConnection:32: WARNING: Unknown target name: "data".
looking for now-outdated files... none found
pickling environment... done
checking consistency... /home/papgft/Dokumente/Fuzzer/boofuzz/origin/docs/source/boofuzz.event_hook.rst: WARNING: document isn't included in any toctree
/home/papgft/Dokumente/Fuzzer/boofuzz/origin/docs/source/boofuzz.helpers.rst: WARNING: document isn't included in any toctree
/home/papgft/Dokumente/Fuzzer/boofuzz/origin/docs/source/boofuzz.instrumentation.rst: WARNING: document isn't included in any toctree
/home/papgft/Dokumente/Fuzzer/boofuzz/origin/docs/source/boofuzz.ip_constants.rst: WARNING: document isn't included in any toctree
/home/papgft/Dokumente/Fuzzer/boofuzz/origin/docs/source/boofuzz.pedrpc.rst: WARNING: document isn't included in any toctree
/home/papgft/Dokumente/Fuzzer/boofuzz/origin/docs/source/boofuzz.utils.crash_binning.rst: WARNING: document isn't included in any toctree
/home/papgft/Dokumente/Fuzzer/boofuzz/origin/docs/source/boofuzz.utils.dcerpc.rst: WARNING: document isn't included in any toctree
/home/papgft/Dokumente/Fuzzer/boofuzz/origin/docs/user/contributing.rst: WARNING: document isn't included in any toctree
done
preparing documents... done
writing output... [100%] user/static-protocol-definition                                                                                                                                                    
generating indices... genindex py-modindex
highlighting module code... [100%] boofuzz.event_hook                                                                                                                                                       
writing additional pages... search
copying images... [100%] _static/boo.png                                                                                                                                                                    
copying static files... done
copying extra files... done
dumping search index in English (code: en) ... done
dumping object inventory... done
build succeeded, 9 warnings.

Build finished. The HTML pages are in _build/html.
```