### PR TITLE
procmon error handling (file not found) and code cleanup

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,10 @@
+Upcoming
+========
+Fixes
+=====
+- Windows process monitor now handles combination of proc_name and/or start_commands more reasonably
+- Windows process monitor handles certain errors more gracefully
+
 v0.1.3
 ======
 Features

--- a/boofuzz/utils/debugger_thread_pydbg.py
+++ b/boofuzz/utils/debugger_thread_pydbg.py
@@ -8,10 +8,6 @@ import sys
 import pydbg
 import pydbg.defines
 
-if not getattr(__builtins__, "WindowsError", None):
-    class WindowsError(OSError):
-        pass
-
 
 class DebuggerThreadPydbg(threading.Thread):
     def __init__(self, start_commands, process_monitor,
@@ -102,9 +98,9 @@ class DebuggerThreadPydbg(threading.Thread):
         for command in self.start_commands:
             try:
                 self._process = subprocess.Popen(command)
-            except WindowsError as e:
-                print('WindowsError "{0}" while starting "{1}"'.format(e.strerror, command), file=sys.stderr)
-                return False
+            except OSError as e:
+                print('OSError "{0}" while starting "{1}"'.format(e.strerror, command), file=sys.stderr)
+                raise
         self.log("done. target up and running, giving it 5 seconds to settle in.")
         time.sleep(5)
         self.pid = self._process.pid
@@ -113,19 +109,19 @@ class DebuggerThreadPydbg(threading.Thread):
         """
         Main thread routine, called on thread.start(). Thread exits when this routine returns.
         """
-        if len(self.start_commands) > 0 and self.proc_name is not None:
-            self.spawn_target()
-            self.watch()
-        elif len(self.start_commands) > 0:
-            self.spawn_target()
-        elif self.proc_name is not None:
-            self.watch()
-        else:
-            self.process_monitor.log("error: procmon has no start command or process name to attach to!")
-            return False
-
-        self.process_monitor.log("debugger thread-%s attaching to pid: %s" % (self.getName(), self.pid))
         try:
+            if len(self.start_commands) > 0 and self.proc_name is not None:
+                self.spawn_target()
+                self.watch()
+            elif len(self.start_commands) > 0:
+                self.spawn_target()
+            elif self.proc_name is not None:
+                self.watch()
+            else:
+                self.process_monitor.log("error: procmon has no start command or process name to attach to!")
+                return False
+
+            self.process_monitor.log("debugger thread-%s attaching to pid: %s" % (self.getName(), self.pid))
             self.dbg.attach(self.pid)
         except pydbg.pdx as e:
             self.process_monitor.log("error: pydbg: {0}".format(str(e).rstrip()))
@@ -134,7 +130,8 @@ class DebuggerThreadPydbg(threading.Thread):
                                          " supports targeting 32-bit processes.")
             elif "Access is denied." in str(e):
                 self.process_monitor.log("It may be that your process died before it could be attached.")
-        self.finished_starting.set()
+        finally:
+            self.finished_starting.set()
         self.dbg.run()
         self.process_monitor.log("debugger thread-%s exiting" % self.getName())
 
@@ -144,18 +141,23 @@ class DebuggerThreadPydbg(threading.Thread):
         Update self.pid when found and return.
         """
         self.process_monitor.log(
-            "debugger thread-%s looking for process name: %s" % (self.getName(), self.proc_name))
+            "debugger thread-{0} looking for process name: {1}".format(self.getName(), self.proc_name))
 
+        self.pid = self._scan_proc_names_blocking()
+
+        self.process_monitor.log("debugger thread-{0} match on pid {1}".format(self.getName(), self.pid))
+
+    def _scan_proc_names_blocking(self):
+        pid = None
+        while pid is None:
+            pid = self._scan_proc_names_once()
+        return pid
+
+    def _scan_proc_names_once(self):
         for (pid, name) in self.dbg.enumerate_processes():
-            # ignore the optionally specified PID.
-            if pid == self.ignore_pid:
-                continue
-
-            if name.lower() == self.proc_name.lower():
-                self.pid = pid
-                break
-
-        self.process_monitor.log("debugger thread-%s found match on pid %d" % (self.getName(), self.pid))
+            if name.lower() == self.proc_name.lower() and pid != self.ignore_pid:
+                return pid
+        return None
 
     def stop_target(self):
         try:


### PR DESCRIPTION
Addresses some issues mentioned in Issue #237 still present after PR #238.

Manually tested: Using procmon with proc name, start command, or both.