### PR TITLE
Add options for callback functions to Sessions.py

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,7 +3,7 @@ Upcoming
 
 Features
 --------
-- New Session options `restart_callback`, `pre_send_callback`, and `post_test_case_callback` to hand over custom callback functions.
+- New Session options `restart_callbacks`, `pre_send_callbacks`, and `post_test_case_callbacks` to hand over custom callback functions.
 - New Session option `fuzz_db_keep_only_n_pass_cases`. This allowes saving only n test cases preceding a failure or error to the database.
 - Added logic to find next available port for web interface or disable the web interface.
 - Removed sleep logs when sleep time is zero.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,7 @@ Upcoming
 
 Features
 --------
+- New Session options `restart_callback`, `pre_send_callback`, and `post_test_case_callback` to hand over custom callback functions.
 - New Session option `fuzz_db_keep_only_n_pass_cases`. This allowes saving only n test cases preceding a failure or error to the database.
 
 Fixes

--- a/boofuzz/constants.py
+++ b/boofuzz/constants.py
@@ -20,4 +20,4 @@ ERR_CONN_RESET = "Target connection reset."
 
 ERR_CONN_RESET_FAIL = "Target connection reset -- considered a failure case when triggered from post_send"
 
-ERR_CALLBACK_FUNC = "A custom {func_name} callback function raised an uncought error. Stopping test run.\n"
+ERR_CALLBACK_FUNC = "A custom {func_name} callback function raised an uncought error.\n"

--- a/boofuzz/constants.py
+++ b/boofuzz/constants.py
@@ -19,3 +19,5 @@ ERR_CONN_ABORTED = "Target connection lost (socket error: {socket_errno} {socket
 ERR_CONN_RESET = "Target connection reset."
 
 ERR_CONN_RESET_FAIL = "Target connection reset -- considered a failure case when triggered from post_send"
+
+ERR_CALLBACK_FUNC = "A custom {func_name} callback function raised an uncought error. Stopping test run.\n"

--- a/boofuzz/exception.py
+++ b/boofuzz/exception.py
@@ -9,6 +9,10 @@ class BoofuzzRestartFailedError(BoofuzzError):
     pass
 
 
+class BoofuzzCallbackError(BoofuzzError):
+    pass
+
+
 class BoofuzzTargetConnectionFailedError(BoofuzzError):
     pass
 

--- a/boofuzz/exception.py
+++ b/boofuzz/exception.py
@@ -9,10 +9,6 @@ class BoofuzzRestartFailedError(BoofuzzError):
     pass
 
 
-class BoofuzzCallbackError(BoofuzzError):
-    pass
-
-
 class BoofuzzTargetConnectionFailedError(BoofuzzError):
     pass
 

--- a/boofuzz/fuzz_logger_db.py
+++ b/boofuzz/fuzz_logger_db.py
@@ -131,8 +131,6 @@ class FuzzLoggerDb(ifuzz_logger_backend.IFuzzLoggerBackend):
                 self._database_connection.commit()
                 self._log_first_case = False
                 self._fail_detected = False
-        else:
-            pass
 
 
 class FuzzLoggerDbReader(object):

--- a/boofuzz/fuzz_logger_db.py
+++ b/boofuzz/fuzz_logger_db.py
@@ -20,6 +20,7 @@ def hex_to_hexstr(input_bytes):
     """
     return helpers.hex_str(input_bytes)
 
+
 DEFAULT_HEX_TO_STR = hex_to_hexstr
 
 
@@ -74,39 +75,39 @@ class FuzzLoggerDb(ifuzz_logger_backend.IFuzzLoggerBackend):
         self._current_test_case_index = index
 
     def open_test_step(self, description):
-        self._queue.append(["INSERT INTO steps VALUES(?, ?, ?, ?, ?);\n",
-            self._current_test_case_index, 'step', description, b'', helpers.get_time_stamp()])
+        self._queue.append(["INSERT INTO steps VALUES(?, ?, ?, ?, ?);\n", self._current_test_case_index, 'step',
+                            description, b'', helpers.get_time_stamp()])
 
     def log_check(self, description):
-        self._queue.append(["INSERT INTO steps VALUES(?, ?, ?, ?, ?);\n",
-            self._current_test_case_index, 'check', description, b'', helpers.get_time_stamp()])
+        self._queue.append(["INSERT INTO steps VALUES(?, ?, ?, ?, ?);\n", self._current_test_case_index, 'check',
+                            description, b'', helpers.get_time_stamp()])
 
     def log_error(self, description):
-        self._queue.append(["INSERT INTO steps VALUES(?, ?, ?, ?, ?);\n",
-            self._current_test_case_index, 'error', description, b'', helpers.get_time_stamp()])
+        self._queue.append(["INSERT INTO steps VALUES(?, ?, ?, ?, ?);\n", self._current_test_case_index, 'error',
+                            description, b'', helpers.get_time_stamp()])
         self._fail_detected = True
         self._write_log()
 
     def log_recv(self, data):
-        self._queue.append(["INSERT INTO steps VALUES(?, ?, ?, ?, ?);\n",
-            self._current_test_case_index, 'receive', u'', buffer(data), helpers.get_time_stamp()])
+        self._queue.append(["INSERT INTO steps VALUES(?, ?, ?, ?, ?);\n", self._current_test_case_index, 'receive',
+                            u'', buffer(data), helpers.get_time_stamp()])
 
     def log_send(self, data):
-        self._queue.append(["INSERT INTO steps VALUES(?, ?, ?, ?, ?);\n",
-            self._current_test_case_index, 'send', u'', buffer(data), helpers.get_time_stamp()])
+        self._queue.append(["INSERT INTO steps VALUES(?, ?, ?, ?, ?);\n", self._current_test_case_index, 'send',
+                            u'', buffer(data), helpers.get_time_stamp()])
 
     def log_info(self, description):
-        self._queue.append(["INSERT INTO steps VALUES(?, ?, ?, ?, ?);\n",
-            self._current_test_case_index, 'info', description, b'', helpers.get_time_stamp()])
+        self._queue.append(["INSERT INTO steps VALUES(?, ?, ?, ?, ?);\n", self._current_test_case_index, 'info',
+                            description, b'', helpers.get_time_stamp()])
 
     def log_fail(self, description=""):
-        self._queue.append(["INSERT INTO steps VALUES(?, ?, ?, ?, ?);\n",
-            self._current_test_case_index, 'fail', description, b'', helpers.get_time_stamp()])
+        self._queue.append(["INSERT INTO steps VALUES(?, ?, ?, ?, ?);\n", self._current_test_case_index, 'fail',
+                            description, b'', helpers.get_time_stamp()])
         self._fail_detected = True
 
     def log_pass(self, description=""):
-        self._queue.append(["INSERT INTO steps VALUES(?, ?, ?, ?, ?);\n",
-            self._current_test_case_index, 'pass', description, b'', helpers.get_time_stamp()])
+        self._queue.append(["INSERT INTO steps VALUES(?, ?, ?, ?, ?);\n", self._current_test_case_index, 'pass',
+                            description, b'', helpers.get_time_stamp()])
 
     def close_test_case(self):
         self._write_log(force=False)
@@ -115,21 +116,23 @@ class FuzzLoggerDb(ifuzz_logger_backend.IFuzzLoggerBackend):
         self._write_log(force=True)
 
     def _write_log(self, force=False):
+        if len(self._queue) > 0:
+            if self._queue_max_len > 0:
+                while (self._current_test_case_index - next(
+                        x for x in self._queue[0] if isinstance(x, (int, long)))) >= self._queue_max_len:
+                    self._queue.popleft()
+            else:
+                force = True
 
-        if self._queue_max_len > 0:
-            while (self._current_test_case_index - next(
-                    x for x in self._queue[0] if isinstance(x, (int, long)))) >= self._queue_max_len:
-                self._queue.popleft()
+            if force or self._fail_detected or self._log_first_case:
+                for query in self._queue:
+                    self._db_cursor.execute(query[0], query[1:])
+                self._queue.clear()
+                self._database_connection.commit()
+                self._log_first_case = False
+                self._fail_detected = False
         else:
-            force=True
-
-        if force or self._fail_detected or self._log_first_case:
-            for query in self._queue:
-                self._db_cursor.execute(query[0], query[1:])
-            self._queue.clear()
-            self._database_connection.commit()
-            self._log_first_case = False
-            self._fail_detected = False
+            pass
 
 
 class FuzzLoggerDbReader(object):

--- a/boofuzz/sessions.py
+++ b/boofuzz/sessions.py
@@ -924,7 +924,6 @@ class Session(pgraph.Graph):
             except Exception:
                 self._fuzz_data_logger.log_error(constants.ERR_CALLBACK_FUNC.format(func_name="pre_send")
                                                  + traceback.format_exc())
-                target.close()
 
     def _restart_target(self, target):
         """

--- a/unit_tests/test_session_failure_handling.py
+++ b/unit_tests/test_session_failure_handling.py
@@ -164,7 +164,7 @@ class TestNoResponseFailure(unittest.TestCase):
             fuzz_loggers=[],  # log to nothing
             check_data_received_each_request=True,
         )
-        session.restart_target = self._mock_restart_target()
+        session._restart_target = self._mock_restart_target()
 
         s_initialize("test-msg-a")
         s_string("test-str-value")


### PR DESCRIPTION
- Added pre_send, restart_target callbacks plus exception handling
- Modified post_send callback (backward compatible)
- Fixed error in fuzz_logger_db when trying to force write without log lines to be written
- Minor changes to some expressions
- Implementation of #239 