### PR TITLE
Fix setup.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,6 @@ sudo: required
 
 before_install: sudo sed -i -e 's/^Defaults\tsecure_path.*$//' /etc/sudoers
 
-install:
-  - pip install tox sphinx
-  - pip install .
-
 stages:
   - Test
   - name: Deploy
@@ -16,8 +12,12 @@ stages:
 jobs:
   include:
     - stage: Test
+      install: pip install tox .
+      script: tox --recreate
+    - # Same stage name
+      install: pip install sphinx
       script:
-        - tox --recreate
+        - python setup.py install --force
         - make -C ./docs dummy
     - stage: Deploy
       script: skip

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,10 @@ stages:
 jobs:
   include:
     - stage: Test
-      install: pip install tox .
-      script: tox --recreate
-    - # Same stage name
-      install: pip install sphinx
+      install: pip install tox sphinx .
       script:
-        - python setup.py install --force
+        - pip check
+        - tox --recreate
         - make -C ./docs dummy
     - stage: Deploy
       script: skip

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         package_data={'boofuzz': ['web/templates/*', 'web/static/css/*', 'web/static/js/*']},
         install_requires=[
             'future', 'pyserial', 'pydot', 'tornado~=4.0',
-            'Flask~=1.0', 'impacket', 'colorama', 'attrs', 'click', 'psutil'],
+            'Flask~=1.0', 'impacket', 'colorama', 'attrs', 'click', 'psutil', 'ldap3==2.5.1'],
         extras_require={
             # This list is duplicated in tox.ini. Make sure to change both!
             'dev': ['check-manifest',

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ setup(
             # This list is duplicated in tox.ini. Make sure to change both!
             'dev': ['check-manifest',
                     'mock',
-                    'pytest==3.6.4',  # temporary measure -- 3.7 was causing pytest-bdd failures
+                    'pytest',
                     'pytest-bdd',
                     'netifaces',
                     'ipaddress'],


### PR DESCRIPTION
Impacket requires both ldap3 and ldapdomaindump, while ldapdomaindump requires ldap3==2.5.1.
Apparently ldap3 2.5.2 is installed before knowing of this requirement so the installation fails.

This should only be a temporary fix, we might want to consider removing impacket completely.
The only occurence of it is in network_monitor.py which is marked as depreciated.