### PR TITLE
Fix pypi autodeploy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ before_install: sudo sed -i -e 's/^Defaults\tsecure_path.*$//' /etc/sudoers
 
 stages:
   - Test
-  - name: Deploy
-    if: (repo = jtpereyda/boofuzz) AND (fork = false) AND (tag IS present)
 
 jobs:
   include:
@@ -17,12 +15,13 @@ jobs:
         - pip check
         - tox --recreate
         - make -C ./docs dummy
-    - stage: Deploy
-      script: skip
       deploy:
         provider: pypi
         user: jtpereyda
         password:
           secure: GD7YRd2CmeSheZ4A85jVFp/aOLGD75M9WjK/Xc7d99OMBp19porIPbkYi+n+X/CQjl4lzUDVGNfvVZKXGVrY+QPxclfAHHIgb7Tc4nXFOWgaXrvw3LWsSfDreANacC105RGC3siGBkAWnMQgO/Q6N3LDHgy7A7XOa8t6sxedxeu1j0cJa0PmrQnvQy6+G+EpxxgrDphy5vwsIwEwRXRD6+4ekFKG81s7aWL1gvGcic/8JSnhc+jpNkbYrcf3edLT8NyMQlTnoplAYNrCMhPaFkNkstFlJvq2m84WlYUiqkTHOyPla07qaJaGPDt89LqqRISX2SNm2BjG5SqJ+6IkloS3Re83kzWL0kSXr9g4sqeCtsvvOhatEeRWEaOzCEE6pK5feLnagZKUL1ZXPu6ywl+yxxK5jcJE2PklvdMCL2KjdlF4CtMp3yg9a6X6VuPunzoXxVUn0cpj7xqenhMz2nDw1s7ZqFrCQ8ed8Pp+TfbmwZfnZ7GSdvywA4CaapOTLOfP4tWcV9GWiLOo0BjIFMac1tJCsHTjuQeRiUO47hpKGHf8+I7qltzlBJJNf/FGUoSqZjzy4o3zbuzfQHQbo2ueI8aS2C5VjjunbivBjp54eoIiu9rPbZl3uHmMWR74Stch0S2Amfj7d0ovZlaljkWWOf4R0tkuxDCtg+vnsy8=
         distributions: sdist bdist_wheel
-        skip_cleanup: true
+        on:
+          tags: true
+          repo: jtpereyda/boofuzz
+          branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ before_install: sudo sed -i -e 's/^Defaults\tsecure_path.*$//' /etc/sudoers
 stages:
   - Test
   - name: Deploy
-    if: (branch = master) AND (repo = jtpereyda/boofuzz) AND (tag IS present)
+    if: (repo = jtpereyda/boofuzz) AND (fork = false) AND (tag IS present)
 
 jobs:
   include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ jobs:
         password:
           secure: GD7YRd2CmeSheZ4A85jVFp/aOLGD75M9WjK/Xc7d99OMBp19porIPbkYi+n+X/CQjl4lzUDVGNfvVZKXGVrY+QPxclfAHHIgb7Tc4nXFOWgaXrvw3LWsSfDreANacC105RGC3siGBkAWnMQgO/Q6N3LDHgy7A7XOa8t6sxedxeu1j0cJa0PmrQnvQy6+G+EpxxgrDphy5vwsIwEwRXRD6+4ekFKG81s7aWL1gvGcic/8JSnhc+jpNkbYrcf3edLT8NyMQlTnoplAYNrCMhPaFkNkstFlJvq2m84WlYUiqkTHOyPla07qaJaGPDt89LqqRISX2SNm2BjG5SqJ+6IkloS3Re83kzWL0kSXr9g4sqeCtsvvOhatEeRWEaOzCEE6pK5feLnagZKUL1ZXPu6ywl+yxxK5jcJE2PklvdMCL2KjdlF4CtMp3yg9a6X6VuPunzoXxVUn0cpj7xqenhMz2nDw1s7ZqFrCQ8ed8Pp+TfbmwZfnZ7GSdvywA4CaapOTLOfP4tWcV9GWiLOo0BjIFMac1tJCsHTjuQeRiUO47hpKGHf8+I7qltzlBJJNf/FGUoSqZjzy4o3zbuzfQHQbo2ueI8aS2C5VjjunbivBjp54eoIiu9rPbZl3uHmMWR74Stch0S2Amfj7d0ovZlaljkWWOf4R0tkuxDCtg+vnsy8=
         distributions: sdist bdist_wheel
+        skip_cleanup: true
         on:
           tags: true
           repo: jtpereyda/boofuzz


### PR DESCRIPTION
Addressing #254.
I'm not exactly sure if `fork = false` is what we need here. The [docs](https://docs.travis-ci.com/user/conditions-v1) aren't too detailed sadly. This condition might be redundant with `repo = jtpereyda/boofuzz`

The `branch = master` condition doesn't match your release workflow. You create a release prep branch, change things there and merge it back with as PR. So when travis runs, it sees that the branch is not master and skips the deploy stage.
So either we get rid of that condition or you have to push a last, possibly empty but tagged, commit directly to master to trigger future releases.