### PR TITLE
Moved checks to tox, added syntax check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,8 @@ stages:
 jobs:
   include:
     - stage: Test
-      install: pip install tox sphinx .
-      script:
-        - pip check
-        - tox --recreate
-        - make -C ./docs dummy
+      install: pip install tox
+      script: tox --recreate
     - stage: Deploy
       script: skip
       deploy:

--- a/boofuzz/__init__.py
+++ b/boofuzz/__init__.py
@@ -477,7 +477,7 @@ def s_mirror(primitive_name, name=None):
     :param name:            (Optional, def=None) Name of current primitive
     """
     if primitive_name not in blocks.CURRENT.names:
-        raise sex.SullyRuntimeError("CAN NOT ADD A MIRROR FOR A NON-EXIST PRIMITIVE CURRENTLY")
+        raise exception.SullyRuntimeError("CAN NOT ADD A MIRROR FOR A NON-EXIST PRIMITIVE CURRENTLY")
 
     mirror = primitives.Mirror(primitive_name, blocks.CURRENT, name)
     blocks.CURRENT.push(mirror)

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -10,6 +10,7 @@ if "%SPHINXBUILD%" == "" (
 set SOURCEDIR=.
 set BUILDDIR=_build
 set SPHINXPROJ=boofuzz
+set SPHINXOPTS=-TW
 
 if "%1" == "" goto help
 

--- a/setup.py
+++ b/setup.py
@@ -36,12 +36,15 @@ setup(
             'Flask~=1.0', 'impacket', 'colorama', 'attrs', 'click', 'psutil', 'ldap3==2.5.1'],
         extras_require={
             # This list is duplicated in tox.ini. Make sure to change both!
-            'dev': ['check-manifest',
+            'dev': ['tox',
+                    'flake8',
+                    'check-manifest',
                     'mock',
                     'pytest',
                     'pytest-bdd',
                     'netifaces',
-                    'ipaddress'],
+                    'ipaddress',
+                    'sphinx'],
         },
         entry_points={
             'console_scripts': ['boo=boofuzz.cli:main'],

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ install_command =
 commands_pre =
     python -m pip check
     # Stop the test if there are Python syntax errors or undefined names.
-    flake8 . --count --select=E901,E999,F821,F822,F823 --exclude=./utils/ida_fuzz_library_extender.py --show-source --statistics
+    flake8 . --count --select=E901,E999,F821,F822,F823 --per-file-ignores='utils/ida_fuzz_library_extender.py:F821' --show-source --statistics
     # Code-Style check. exit-zero treats all errors as warnings. Ignoring F405 because we use many star imports.
     # Use '# noqa: F401' for in-line ignores.
     flake8 . --count --exit-zero --ignore F405 --max-complexity=10 --max-line-length=120 --statistics

--- a/tox.ini
+++ b/tox.ini
@@ -14,7 +14,7 @@ install_command =
 commands_pre =
     python -m pip check
     # Stop the test if there are Python syntax errors or undefined names.
-    flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+    flake8 . --count --select=E901,E999,F821,F822,F823 --exclude=./utils/ida_fuzz_library_extender.py --show-source --statistics
     # Code-Style check. exit-zero treats all errors as warnings. Ignoring F405 because we use many star imports.
     # Use '# noqa: F401' for in-line ignores.
     flake8 . --count --exit-zero --ignore F405 --max-complexity=10 --max-line-length=120 --statistics

--- a/tox.ini
+++ b/tox.ini
@@ -22,6 +22,8 @@ commands =
     windows: python -m pytest
     unix: sudo {envpython} -m pytest
     python -m check_manifest
-    unix: make -C ./docs dummy # TODO: Add same command for Windows
+    windows: .\docs\make.bat dummy
+    unix: make -C ./docs dummy
 commands_post =
+    windows: rmdir /S /Q .\boofuzz-results .\docs\_build
     unix: sudo rm -rf ./boofuzz-results/ ./docs/_build/

--- a/tox.ini
+++ b/tox.ini
@@ -2,14 +2,26 @@
 envlist = py27-{unix,windows}
 
 [testenv]
-whitelist_externals=sudo
-platform=
+whitelist_externals =
+    sudo
+    make
+platform =
     windows: win32
     unix: linux2|darwin
 extras = dev
 install_command =
     python -m pip install {opts} {packages}
+commands_pre =
+    python -m pip check
+    # Stop the test if there are Python syntax errors or undefined names.
+    flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+    # Code-Style check. exit-zero treats all errors as warnings. Ignoring F405 because we use many star imports.
+    # Use '# noqa: F401' for in-line ignores.
+    flake8 . --count --exit-zero --ignore F405 --max-complexity=10 --max-line-length=120 --statistics
 commands =
     windows: python -m pytest
     unix: sudo {envpython} -m pytest
     python -m check_manifest
+    unix: make -C ./docs dummy # TODO: Add same command for Windows
+commands_post =
+    unix: sudo rm -rf ./boofuzz-results/ ./docs/_build/


### PR DESCRIPTION
- All checks previously performed on travis can now also be run locally with tox
- Added flake8 syntax checking for both critical errors and code-style warnings
- Updated [dev] dependencies

The idea behind this is to make it possible to easily perform the same checks as travis does locally with tox.
It would be nice to know how the equivalent to `make -C ./docs dummy` for Windows too.

I've already fixed one error in the ini.py but I could use some help fixing utils/ida_fuzz_library_extender.py which seems to be missing some dependencies. Checks will fail because of this.

@jtpereyda I also looked into ways to add codecov to the CI if you're interested. Personally, I don't like the fact that a bot comments the report after every commit to a PR. Would look something like [this](https://github.com/codecov/example-python/pull/26).