### PR TITLE
Added keep_web_open session option

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,8 @@
 Upcoming
 ========
+Features
+--------
+- New Session option `keep_web_open` to allow analyzing the test results after test completion.
 
 v0.1.4
 ======

--- a/boofuzz/sessions.py
+++ b/boofuzz/sessions.py
@@ -693,8 +693,6 @@ class Session(pgraph.Graph):
                 print("\nFuzzing session completed. Keeping webinterface up on localhost:{}".format(self.web_port),
                       "\nPress ENTER to close webinterface")
                 raw_input()
-            else:
-                print("\nFuzzing session completed. Webinterface will be available as long as this script is running.")
         except KeyboardInterrupt:
             # TODO: should wait for the end of the ongoing test case, and stop gracefully netmon and procmon
             self.export_file()

--- a/boofuzz/sessions.py
+++ b/boofuzz/sessions.py
@@ -1,4 +1,4 @@
-from __future__ import absolute_import
+from __future__ import absolute_import, print_function
 
 import cPickle
 import datetime
@@ -287,6 +287,7 @@ class Session(pgraph.Graph):
         post_test_case_callbacks (list of method): The registered method will be called after each fuzz test case.
                                                   Default None.
         web_port (int):         Port for monitoring fuzzing campaign via a web browser. Default 26000.
+        keep_web_open (bool):     Keep the webinterface open after session completion. Default True.
         fuzz_data_logger (fuzz_logger.FuzzLogger): DEPRECATED. Use fuzz_loggers instead.
         fuzz_loggers (list of ifuzz_logger.IFuzzLogger): For saving test data and results.. Default Log to STDOUT.
         fuzz_db_keep_only_n_pass_cases (int): Minimize disk usage by only saving passing test cases
@@ -322,6 +323,7 @@ class Session(pgraph.Graph):
     def __init__(self, session_filename=None, index_start=1, index_end=None, sleep_time=0.0,
                  restart_interval=0,
                  web_port=constants.DEFAULT_WEB_UI_PORT,
+                 keep_web_open=True,
                  crash_threshold_request=12,
                  crash_threshold_element=3,
                  restart_sleep_time=5,
@@ -357,6 +359,7 @@ class Session(pgraph.Graph):
         self.sleep_time = sleep_time
         self.restart_interval = restart_interval
         self.web_port = web_port
+        self._keep_web_open = keep_web_open
         self._crash_threshold_node = crash_threshold_request
         self._crash_threshold_element = crash_threshold_element
         self.restart_sleep_time = restart_sleep_time
@@ -685,6 +688,13 @@ class Session(pgraph.Graph):
             self._fuzz_data_logger.close_test()
             if self._reuse_target_connection:
                 self.targets[0].close()
+
+            if self._keep_web_open and self.web_port is not None:
+                print("\nFuzzing session completed. Keeping webinterface up on localhost:{}".format(self.web_port),
+                      "\nPress ENTER to close webinterface")
+                raw_input()
+            else:
+                print("\nFuzzing session completed. Webinterface will be available as long as this script is running.")
         except KeyboardInterrupt:
             # TODO: should wait for the end of the ongoing test case, and stop gracefully netmon and procmon
             self.export_file()

--- a/unit_tests/test_session_failure_handling.py
+++ b/unit_tests/test_session_failure_handling.py
@@ -163,6 +163,7 @@ class TestNoResponseFailure(unittest.TestCase):
             ),
             fuzz_loggers=[],  # log to nothing
             check_data_received_each_request=True,
+            keep_web_open=False,
         )
         session._restart_target = self._mock_restart_target()
 


### PR DESCRIPTION
Easiest way I found to implement #166.
Default value is True currently as I think that's the most user friendly. If anyone is using boofuzz in an automated environment, this will break the flow, but is easy to fix. Maybe add a warning to the changelog?

This can still be optimised, e.g. spin off another process and release the command line, but I'll leave that for another time. Thinking about it, how would you close the now seperated web-process? Also the next session would have to reconnect to that process so that there aren't more and more spawning. Seems to be quite complicated...