### PR TITLE
Fix tox platform mismatch with travis

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ whitelist_externals =
     make
 platform =
     windows: win32
-    unix: linux2|darwin
+    unix: linux|darwin
 extras = dev
 install_command =
     python -m pip install {opts} {packages}


### PR DESCRIPTION
It seems that the travis platform for linux has changed from linux2 to linux.
https://travis-ci.org/jtpereyda/boofuzz/builds/525628755