### PR TITLE
various fixes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,15 @@ Upcoming
 Features
 --------
 - New Session option `keep_web_open` to allow analyzing the test results after test completion.
+- Large test cases are now truncated, unless a failure is detected.
+- When a target fails to respond after restart, boofuzz will now continue to restart instead of crashing.
+- Process monitor creates new crash file for each run by default.
+- Long lines now wrap in web view; longer lines no longer need to be truncated.
+
+Fixes
+-----
+- Web server no longer crashes when asked for a non-existing test case.
+- EINPROGRESS socket error is now handled while opening a socket (note: this sometimes-transient error motivated the move to retry upon connection failure)
 
 v0.1.4
 ======

--- a/boofuzz/constants.py
+++ b/boofuzz/constants.py
@@ -12,6 +12,9 @@ ERR_CONN_FAILED_TERMINAL = "Cannot connect to target; target presumed down. Stop
 ERR_CONN_FAILED = "Cannot connect to target; target presumed down. Note: This likely " \
                   "indicates a failure caused by the previous test case. "
 
+WARN_CONN_FAILED_TERMINAL = "Cannot connect to target; retrying. Note: This likely " \
+                            "indicates a failure caused by the previous test case, or a target that is slow to restart."
+
 ERR_CONN_ABORTED = "Target connection lost (socket error: {socket_errno} {socket_errmsg}): You may have a " \
                    "network issue, or an issue with firewalls or anti-virus. Try " \
                    "disabling your firewall."

--- a/boofuzz/data_test_step.py
+++ b/boofuzz/data_test_step.py
@@ -11,6 +11,7 @@ class DataTestStep(object):
     description = attr.ib()
     data = attr.ib()
     timestamp = attr.ib()
+    truncated = attr.ib(type=bool)
 
     @property
     def text_render(self):
@@ -19,6 +20,7 @@ class DataTestStep(object):
             description=self.description,
             data=self.data,
             timestamp=self.timestamp,
+            truncated=self.truncated,
             format_type='terminal',
         )
 
@@ -29,6 +31,7 @@ class DataTestStep(object):
             description=self.description,
             data=self.data,
             timestamp=self.timestamp,
+            truncated=self.truncated,
             format_type='html',
         )
 

--- a/boofuzz/exception.py
+++ b/boofuzz/exception.py
@@ -26,6 +26,10 @@ class BoofuzzTargetConnectionAborted(BoofuzzError):
     socket_errmsg = attr.ib()
 
 
+class BoofuzzNoSuchTestCase(BoofuzzError):
+    pass
+
+
 class BoofuzzRpcError(BoofuzzError):
     pass
 

--- a/boofuzz/fuzz_logger_db.py
+++ b/boofuzz/fuzz_logger_db.py
@@ -7,6 +7,7 @@ from . import helpers
 from . import ifuzz_logger_backend
 from . import data_test_case
 from . import data_test_step
+from . import exception
 
 
 def hex_to_hexstr(input_bytes):
@@ -37,7 +38,7 @@ class FuzzLoggerDb(ifuzz_logger_backend.IFuzzLoggerBackend):
         self._db_cursor = self._database_connection.cursor()
         self._db_cursor.execute('''CREATE TABLE cases (name text, number integer, timestamp TEXT)''')
         self._db_cursor.execute(
-            '''CREATE TABLE steps (test_case_index integer, type text, description text, data blob, timestamp TEXT)''')
+            '''CREATE TABLE steps (test_case_index integer, type text, description text, data blob, timestamp TEXT, is_truncated BOOLEAN)''')
 
         self._current_test_case_index = 0
 
@@ -45,6 +46,7 @@ class FuzzLoggerDb(ifuzz_logger_backend.IFuzzLoggerBackend):
         self._queue_max_len = num_log_cases
         self._fail_detected = False
         self._log_first_case = True
+        self._data_truncate_length = 512
 
     def get_test_case_data(self, index):
         c = self._database_connection.cursor()
@@ -66,7 +68,9 @@ class FuzzLoggerDb(ifuzz_logger_backend.IFuzzLoggerBackend):
                     pass
                 else:
                     raise
-            steps.append(data_test_step.DataTestStep(type=row[1], description=row[2], data=data, timestamp=row[4]))
+            steps.append(
+                data_test_step.DataTestStep(
+                    type=row[1], description=row[2], data=data, timestamp=row[4], truncated=row[5]))
         return data_test_case.DataTestCase(name=test_case_row[0], index=test_case_row[1], timestamp=test_case_row[2],
                                            steps=steps)
 
@@ -75,39 +79,39 @@ class FuzzLoggerDb(ifuzz_logger_backend.IFuzzLoggerBackend):
         self._current_test_case_index = index
 
     def open_test_step(self, description):
-        self._queue.append(["INSERT INTO steps VALUES(?, ?, ?, ?, ?);\n", self._current_test_case_index, 'step',
-                            description, b'', helpers.get_time_stamp()])
+        self._queue.append(["INSERT INTO steps VALUES(?, ?, ?, ?, ?, ?);\n", self._current_test_case_index, 'step',
+                            description, b'', helpers.get_time_stamp(), False])
 
     def log_check(self, description):
-        self._queue.append(["INSERT INTO steps VALUES(?, ?, ?, ?, ?);\n", self._current_test_case_index, 'check',
-                            description, b'', helpers.get_time_stamp()])
+        self._queue.append(["INSERT INTO steps VALUES(?, ?, ?, ?, ?, ?);\n", self._current_test_case_index, 'check',
+                            description, b'', helpers.get_time_stamp(), False])
 
     def log_error(self, description):
-        self._queue.append(["INSERT INTO steps VALUES(?, ?, ?, ?, ?);\n", self._current_test_case_index, 'error',
-                            description, b'', helpers.get_time_stamp()])
+        self._queue.append(["INSERT INTO steps VALUES(?, ?, ?, ?, ?, ?);\n", self._current_test_case_index, 'error',
+                            description, b'', helpers.get_time_stamp(), False])
         self._fail_detected = True
         self._write_log()
 
     def log_recv(self, data):
-        self._queue.append(["INSERT INTO steps VALUES(?, ?, ?, ?, ?);\n", self._current_test_case_index, 'receive',
-                            u'', buffer(data), helpers.get_time_stamp()])
+        self._queue.append(["INSERT INTO steps VALUES(?, ?, ?, ?, ?, ?);\n", self._current_test_case_index, 'receive',
+                            u'', buffer(data), helpers.get_time_stamp(), False])
 
     def log_send(self, data):
-        self._queue.append(["INSERT INTO steps VALUES(?, ?, ?, ?, ?);\n", self._current_test_case_index, 'send',
-                            u'', buffer(data), helpers.get_time_stamp()])
+        self._queue.append(["INSERT INTO steps VALUES(?, ?, ?, ?, ?, ?);\n", self._current_test_case_index, 'send',
+                            u'', buffer(data), helpers.get_time_stamp(), False])
 
     def log_info(self, description):
-        self._queue.append(["INSERT INTO steps VALUES(?, ?, ?, ?, ?);\n", self._current_test_case_index, 'info',
-                            description, b'', helpers.get_time_stamp()])
+        self._queue.append(["INSERT INTO steps VALUES(?, ?, ?, ?, ?, ?);\n", self._current_test_case_index, 'info',
+                            description, b'', helpers.get_time_stamp(), False])
 
     def log_fail(self, description=""):
-        self._queue.append(["INSERT INTO steps VALUES(?, ?, ?, ?, ?);\n", self._current_test_case_index, 'fail',
-                            description, b'', helpers.get_time_stamp()])
+        self._queue.append(["INSERT INTO steps VALUES(?, ?, ?, ?, ?, ?);\n", self._current_test_case_index, 'fail',
+                            description, b'', helpers.get_time_stamp(), False])
         self._fail_detected = True
 
     def log_pass(self, description=""):
-        self._queue.append(["INSERT INTO steps VALUES(?, ?, ?, ?, ?);\n", self._current_test_case_index, 'pass',
-                            description, b'', helpers.get_time_stamp()])
+        self._queue.append(["INSERT INTO steps VALUES(?, ?, ?, ?, ?, ?);\n", self._current_test_case_index, 'pass',
+                            description, b'', helpers.get_time_stamp(), False])
 
     def close_test_case(self):
         self._write_log(force=False)
@@ -126,11 +130,19 @@ class FuzzLoggerDb(ifuzz_logger_backend.IFuzzLoggerBackend):
 
             if force or self._fail_detected or self._log_first_case:
                 for query in self._queue:
+                    # abbreviate long entries first
+                    if not self._fail_detected:
+                        self._truncate_send_recv(query)
                     self._db_cursor.execute(query[0], query[1:])
                 self._queue.clear()
                 self._database_connection.commit()
                 self._log_first_case = False
                 self._fail_detected = False
+
+    def _truncate_send_recv(self, query):
+        if query[2] in ['send', 'recv'] and len(query[4]) > self._data_truncate_length:
+            query[6] = True
+            query[4] = buffer(query[4][:self._data_truncate_length])
 
 
 class FuzzLoggerDbReader(object):
@@ -145,8 +157,12 @@ class FuzzLoggerDbReader(object):
         self._db_cursor = self._database_connection.cursor()
 
     def get_test_case_data(self, index):
-        c = self._database_connection.cursor()
-        test_case_row = next(c.execute('''SELECT * FROM cases WHERE number=?''', [index]))
+        c = self._db_cursor
+        try:
+            test_case_row = next(c.execute('''SELECT * FROM cases WHERE number=?''', [index]))
+        except StopIteration:
+            raise exception.BoofuzzNoSuchTestCase()
+
         rows = c.execute('''SELECT * FROM steps WHERE test_case_index=?''', [index])
         steps = []
         for row in rows:
@@ -161,13 +177,21 @@ class FuzzLoggerDbReader(object):
                     pass
                 else:
                     raise
-            steps.append(data_test_step.DataTestStep(type=row[1], description=row[2], data=data, timestamp=row[4]))
+            steps.append(
+                data_test_step.DataTestStep(
+                    type=row[1], description=row[2], data=data, timestamp=row[4], truncated=row[5]))
         return data_test_case.DataTestCase(name=test_case_row[0], index=test_case_row[1], timestamp=test_case_row[2],
                                            steps=steps)
 
+    def query(self, query, params=None):
+        if params is None:
+            params = []
+        c = self._db_cursor
+        return c.execute(query, params)
+
     @property
     def failure_map(self):
-        c = self._database_connection.cursor()
+        c = self._db_cursor
         failure_steps = c.execute('''SELECT * FROM steps WHERE type="fail"''')
 
         failure_map = collections.defaultdict(list)

--- a/boofuzz/helpers.py
+++ b/boofuzz/helpers.py
@@ -47,15 +47,15 @@ test_step_info = {
     'send': {
         'indent': 2,
         'title': 'Transmitted',
-        'html': 'Transmitted {n} bytes: {msg}',
-        'terminal': Fore.CYAN + "Transmitted {n} bytes: {msg}" + Style.RESET_ALL,
+        'html': 'Transmitted {n} bytes{note}: {msg}',
+        'terminal': Fore.CYAN + "Transmitted {n} bytes{note}: {msg}" + Style.RESET_ALL,
         'css_class': 'log-send'
     },
     'receive': {
         'indent': 2,
         'title': 'Received',
-        'html': 'Received: {msg}',
-        'terminal': Fore.CYAN + "Received: {msg}" + Style.RESET_ALL,
+        'html': 'Received{note}: {msg}',
+        'terminal': Fore.CYAN + "Received{note}: {msg}" + Style.RESET_ALL,
         'css_class': 'log-receive'
     },
     'check': {
@@ -363,7 +363,7 @@ def _indent_after_first_line(lines, amount, ch=' '):
     return ('\n' + padding).join(lines.split('\n'))
 
 
-def format_log_msg(msg_type, description=None, data=None, indent_size=2, timestamp=None, format_type='terminal'):
+def format_log_msg(msg_type, description=None, data=None, indent_size=2, timestamp=None, truncated=False, format_type='terminal'):
     if data is None:
         data = b''
     if timestamp is None:
@@ -376,7 +376,7 @@ def format_log_msg(msg_type, description=None, data=None, indent_size=2, timesta
     else:
         msg = ''
 
-    msg = test_step_info[msg_type][format_type].format(msg=msg, n=len(data))
+    msg = test_step_info[msg_type][format_type].format(msg=msg, n=len(data), note='' if not truncated else ' (data truncated for database storage)')
     msg = _indent_all_lines(msg, (test_step_info[msg_type]['indent']) * indent_size)
     msg = timestamp + ' ' + _indent_after_first_line(msg, len(timestamp) + 1)
 

--- a/boofuzz/sessions.py
+++ b/boofuzz/sessions.py
@@ -206,11 +206,12 @@ class SessionInfo(object):
 
     @property
     def total_num_mutations(self):
-        return 100  # TODO upgrade database format to store this info
+        return None
 
     @property
     def total_mutant_index(self):
-        return 100  # TODO SELECT COUNT(*) FROM cases -- But watch out for partially finished case
+        x = self._db_reader.query('''SELECT COUNT(*) FROM cases''').next()[0]
+        return x
 
     def test_case_data(self, index):
         """Return test case data object (for use by web server)
@@ -374,6 +375,8 @@ class Session(pgraph.Graph):
         self._db_logger = fuzz_logger_db.FuzzLoggerDb(db_filename=self._db_filename,
                                                       num_log_cases=fuzz_db_keep_only_n_pass_cases)
 
+        self._crash_filename = 'boofuzz-crash-bin-{0}'.format(self._run_id)
+
         self._fuzz_data_logger = fuzz_logger.FuzzLogger(fuzz_loggers=[self._db_logger] + fuzz_loggers)
         self._check_data_received_each_request = check_data_received_each_request
         self._receive_data_after_each_request = receive_data_after_each_request
@@ -423,6 +426,7 @@ class Session(pgraph.Graph):
         self.add_node(self.root)
 
         if target is not None:
+            target.procmon_options['crash_filename'] = self._crash_filename
             try:
                 self.add_target(target=target)
             except exception.BoofuzzRpcError as e:
@@ -1324,12 +1328,7 @@ class Session(pgraph.Graph):
                 self._fuzz_data_logger.open_test_step('Calling netmon pre_send()')
                 target.netmon.pre_send(self.total_mutant_index)
 
-            try:
-                if not self._reuse_target_connection:
-                    target.open()
-            except exception.BoofuzzTargetConnectionFailedError:
-                self._fuzz_data_logger.log_error(constants.ERR_CONN_FAILED_TERMINAL)
-                raise
+            self._open_connection_keep_trying(target)
 
             self._pre_send(target)
 
@@ -1395,12 +1394,7 @@ class Session(pgraph.Graph):
             target.netmon.pre_send(self.total_mutant_index)
 
         try:
-            try:
-                if not self._reuse_target_connection:
-                    target.open()
-            except exception.BoofuzzTargetConnectionFailedError:
-                self._fuzz_data_logger.log_error(constants.ERR_CONN_FAILED_TERMINAL)
-                raise
+            self._open_connection_keep_trying(target)
 
             self._pre_send(target)
 
@@ -1422,13 +1416,31 @@ class Session(pgraph.Graph):
 
             if self.sleep_time > 0:
                 self._fuzz_data_logger.open_test_step("Sleep between tests.")
-                self._fuzz_data_logger.log_info("sleeping for %f seconds" % self.sleep_time)
-                time.sleep(self.sleep_time)
+                self._sleep(self.sleep_time)
         finally:
             self._process_failures(target=target)
             self._stop_netmon(target=target)
             self._fuzz_data_logger.close_test_case()
             self.export_file()
+
+    def _open_connection_keep_trying(self, target):
+        """ Open connection and if it fails, keep retrying.
+
+        Args:
+            target (Target): Target to open.
+        """
+        if not self._reuse_target_connection:
+            while True:
+                try:
+                    target.open()
+                    break  # break if no exception
+                except exception.BoofuzzTargetConnectionFailedError:
+                    self._fuzz_data_logger.log_info(constants.WARN_CONN_FAILED_TERMINAL)
+                    self._restart_target(target)
+
+    def _sleep(self, seconds):
+        self._fuzz_data_logger.log_info("sleeping for %f seconds" % seconds)
+        time.sleep(seconds)
 
     def _test_case_name_feature_check(self, path):
         message_path = "->".join([self.nodes[e.dst].name for e in path])

--- a/boofuzz/socket_connection.py
+++ b/boofuzz/socket_connection.py
@@ -157,7 +157,7 @@ class SocketConnection(itarget_connection.ITargetConnection):
             try:
                 self._sock.connect((self.host, self.port))
             except socket.error as e:
-                if e.errno == errno.ECONNREFUSED:
+                if e.errno in [errno.ECONNREFUSED, errno.EINPROGRESS]:
                     raise exception.BoofuzzTargetConnectionFailedError(e.message)
                 else:
                     raise

--- a/boofuzz/utils/process_monitor_pedrpc_server.py
+++ b/boofuzz/utils/process_monitor_pedrpc_server.py
@@ -200,3 +200,7 @@ class ProcessMonitorPedrpcServer(pedrpc.Server):
         self.log("updating stop commands to: {0}".format(list(new_stop_commands)))
         self.stop_commands = new_stop_commands
         self.stop_commands = map(_split_command_if_str, new_stop_commands)
+
+    def set_crash_filename(self, new_crash_filename):
+        self.log("updating crash bin filename to '%s'" % new_crash_filename)
+        self.crash_filename = new_crash_filename

--- a/boofuzz/web/static/css/boofuzz.css
+++ b/boofuzz/web/static/css/boofuzz.css
@@ -162,7 +162,6 @@ table.test-steps td {
     font-family: "SFMono-Regular",Consolas,"Liberation Mono",Menlo,Courier,monospace;
     margin: 0;
 }
-
 table.test-steps .log-case { color: yellow; }
 table.test-steps .log-step { color: magenta; }
 table.test-steps .log-error { color: red; }
@@ -170,5 +169,21 @@ table.test-steps .log-check { }
 table.test-steps .log-info { }
 table.test-steps .log-pass { color: limegreen; }
 table.test-steps .log-fail { color: red; }
-table.test-steps .log-send { color: darkcyan; }
-table.test-steps .log-receive { color: darkcyan; }
+table.test-steps .log-send { color: darkcyan;
+  /* start break-long-words code */
+  display: inline-block;
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+  word-break: break-all;
+  word-break: break-word;
+  /* end break-long-words code */
+}
+table.test-steps .log-receive { color: darkcyan;
+  /* start break-long-words code */
+  display: inline-block;
+  overflow-wrap: break-word;
+  word-wrap: break-word;
+  word-break: break-all;
+  word-break: break-word;
+  /* end break-long-words code */
+}

--- a/boofuzz/web/static/js/index.js
+++ b/boofuzz/web/static/js/index.js
@@ -71,16 +71,27 @@ function update_current_test_case_log(response) {
 
     // Create log table entries
     let new_entries = document.createElement('tbody');
-    response.log_data.forEach(function(log_entry) {
+    if (response.log_data === null){
         let new_span = document.createElement('span');
-        new_span.setAttribute('class', log_entry.css_class);
-        new_span.textContent = log_entry.log_line;
+        new_span.textContent = 'Test case does not exist'
         let new_td = document.createElement('td');
         let new_tr = document.createElement('tr');
         new_td.appendChild(new_span);
         new_tr.appendChild(new_td);
         new_entries.appendChild(new_tr);
-    });
+    }
+    else{
+        response.log_data.forEach(function(log_entry) {
+            let new_span = document.createElement('span');
+            new_span.setAttribute('class', log_entry.css_class);
+            new_span.textContent = log_entry.log_line;
+            let new_td = document.createElement('td');
+            let new_tr = document.createElement('tr');
+            new_td.appendChild(new_span);
+            new_tr.appendChild(new_td);
+            new_entries.appendChild(new_tr);
+        });
+    }
 
     // Insert log table entries
     let test_cases_table = document.getElementById('test-steps-table');


### PR DESCRIPTION
Features
--------
- Large test cases are now truncated, unless a failure is detected.
- When a target fails to respond after restart, boofuzz will now continue to restart instead of crashing.
- Process monitor creates new crash file for each run by default.
- Long lines now wrap in web view; longer lines no longer need to be truncated.

Fixes
-----
- Web server no longer crashes when asked for a non-existing test case.
- EINPROGRESS socket error is now handled while opening a socket (note: this sometimes-transient error motivated the move to retry upon connection failure)