### PR TITLE
Procmon fixes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -3,6 +3,8 @@ Upcoming
 Features
 --------
 - New Session option `keep_web_open` to allow analyzing the test results after test completion.
+- Process monitor now stores crash bins in JSON format instead of pickled format.
+- Process monitor in Windows will use `taskkill -F`
 
 v0.1.4
 ======

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,7 @@ Features
 - Process monitor creates new crash file for each run by default.
 - Long lines now wrap in web view; longer lines no longer need to be truncated.
 - Process monitor now stores crash bins in JSON format instead of pickled format.
-- Process monitor in Windows will use `taskkill -F`
+- Process monitor in Windows will use `taskkill -F` if `taskkill` fails.
 
 Fixes
 -----

--- a/boofuzz/utils/debugger_thread_pydbg.py
+++ b/boofuzz/utils/debugger_thread_pydbg.py
@@ -162,6 +162,9 @@ class DebuggerThreadPydbg(threading.Thread):
     def stop_target(self):
         try:
             os.system("taskkill /pid %d" % self.pid)
+            exit_code = os.system("taskkill /pid %d" % self.pid)
+            if exit_code != 0:
+                os.system("taskkill -F /pid %d" % self.pid)
         except OSError as e:
             print(e.errno)  # TODO interpret some basic errors
 

--- a/boofuzz/utils/process_monitor_pedrpc_server.py
+++ b/boofuzz/utils/process_monitor_pedrpc_server.py
@@ -200,3 +200,7 @@ class ProcessMonitorPedrpcServer(pedrpc.Server):
         self.log("updating stop commands to: {0}".format(list(new_stop_commands)))
         self.stop_commands = new_stop_commands
         self.stop_commands = map(_split_command_if_str, new_stop_commands)
+
+    def set_crash_filename(self, new_crash_filename):
+        self.log("updating crash bin filename to '%s'" % new_crash_filename)
+        self.crash_filename = new_crash_filename


### PR DESCRIPTION
- Process monitor now stores crash bins in JSON format instead of pickled format.
- Process monitor in Windows will use `taskkill -F` if `taskkill` fails.