### PR TITLE
Fixed Windows unit-tests

### DIFF
--- a/boofuzz/socket_connection.py
+++ b/boofuzz/socket_connection.py
@@ -19,8 +19,8 @@ ETH_P_IP = 0x0800  # Ethernet protocol: Internet Protocol packet, see Linux if_e
 def _seconds_to_second_microsecond_struct(seconds):
     """Convert floating point seconds value to second/useconds struct used by socket library."""
     microseconds_per_second = 1000000
-    whole_seconds = math.floor(seconds)
-    whole_microseconds = math.floor((seconds % 1) * microseconds_per_second)
+    whole_seconds = int(math.floor(seconds))
+    whole_microseconds = int(math.floor((seconds % 1) * microseconds_per_second))
     return struct.pack('ll', whole_seconds, whole_microseconds)
 
 
@@ -272,4 +272,3 @@ class SocketConnection(itarget_connection.ITargetConnection):
     @property
     def info(self):
         return '{0}:{1}'.format(self.host, self.port)
-

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist = py27-{unix,windows}
 whitelist_externals =
     sudo
     make
+    cmd
 platform =
     windows: win32
     unix: linux|darwin
@@ -25,5 +26,5 @@ commands =
     windows: .\docs\make.bat dummy
     unix: make -C ./docs dummy
 commands_post =
-    windows: rmdir /S /Q .\boofuzz-results .\docs\_build
+    windows: - cmd /c for %d in ('boofuzz-results' '.\docs\_build') do rmdir '%~d' /s /q
     unix: sudo rm -rf ./boofuzz-results/ ./docs/_build/

--- a/unit_tests/test_socket_connection.py
+++ b/unit_tests/test_socket_connection.py
@@ -193,6 +193,7 @@ class MiniTestServer(object):
 
         if self.proto == 'tcp':
             (client_socket, address) = self.server_socket.accept()
+            client_socket.settimeout(self.timeout)
 
             self.received = client_socket.recv(10000)
 


### PR DESCRIPTION
Running the unit-tests on Windows fails at `TestSocketConnection.test_tcp_client`.
This is because Windows doesn't allow non-blocking sockets, hence raising [Errno 10035](https://docs.microsoft.com/en-us/windows/desktop/winsock/windows-sockets-error-codes-2)
To fix this, a [timeout](https://docs.python.org/3/library/socket.html#socket.socket.settimeout) for the `client_socket` has to be set too and not only for the server_socket.
There were some deprecation warnings in the socket_connection.py, that were caused by math.floor not returning an int type in python2.

Additionally, I made some changes to the tox commands, they now work as intended.
