### PR TITLE
Run tests against multiple python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,6 @@ jobs:
       env: TOXENV=py36-unix
     - python: 3.7
       env: TOXENV=py37-unix
-    - python: 3.8-dev
-      env: TOXENV=py38-unix
 
     - stage: Deploy
       install: true
@@ -33,10 +31,6 @@ jobs:
           tags: true
           repo: jtpereyda/boofuzz
           branch: master
-
-  fast_finish: true
-  allow_failures:
-    - python: 3.8-dev
 
 before_install: sudo sed -i -e 's/^Defaults\tsecure_path.*$//' /etc/sudoers
 install: pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ jobs:
           repo: jtpereyda/boofuzz
           branch: master
 
+  fast_finish: true
   allow_failures:
     - python: 3.8-dev
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 dist: xenial
 sudo: required
 language: python
-cache: pip
 
 stages:
   - Test
@@ -17,7 +16,7 @@ jobs:
       env: TOXENV=py36-unix
     - python: 3.7
       env: TOXENV=py37-unix
-    - python: 3.8
+    - python: 3.8-dev
       env: TOXENV=py38-unix
 
     - stage: Deploy
@@ -36,7 +35,7 @@ jobs:
           branch: master
 
   allow_failures:
-    - python: 3.8
+    - python: 3.8-dev
 
 before_install: sudo sed -i -e 's/^Defaults\tsecure_path.*$//' /etc/sudoers
 install: pip install tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,28 @@
-language: python
 dist: xenial
 sudo: required
-
-before_install: sudo sed -i -e 's/^Defaults\tsecure_path.*$//' /etc/sudoers
+language: python
+cache: pip
 
 stages:
   - Test
+  - name: Deploy
+    if: (repo = jtpereyda/boofuzz) AND (fork = false) AND (tag IS present)
 
 jobs:
   include:
     - stage: Test
-      install: pip install tox
-      script: tox --recreate
+      python: 2.7
+      env: TOXENV=py27-unix
+    - python: 3.6
+      env: TOXENV=py36-unix
+    - python: 3.7
+      env: TOXENV=py37-unix
+    - python: 3.8
+      env: TOXENV=py38-unix
+
+    - stage: Deploy
+      install: true
+      script: skip
       deploy:
         provider: pypi
         user: jtpereyda
@@ -23,3 +34,10 @@ jobs:
           tags: true
           repo: jtpereyda/boofuzz
           branch: master
+
+  allow_failures:
+    - python: 3.8
+
+before_install: sudo sed -i -e 's/^Defaults\tsecure_path.*$//' /etc/sudoers
+install: pip install tox
+script: tox --skip-missing-interpreters false

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -18,15 +18,17 @@ See installation instructions for details on installing boofuzz from source with
 Pull Request Checklist
 ----------------------
 
-1. Verify tests pass: ::
+1. Install python version 2.7.9+ **and** 3.6+
+
+2. Verify tests pass: ::
 
       tox
 
-2. If you have PyCharm, use it to see if your changes introduce any new static analysis warnings.
+3. If you have PyCharm, use it to see if your changes introduce any new static analysis warnings.
 
-3. Modify CHANGELOG.rst to say what you changed.
+4. Modify CHANGELOG.rst to say what you changed.
 
-4. If adding a new module, consider adding it to the Sphinx docs (see ``docs`` folder).
+5. If adding a new module, consider adding it to the Sphinx docs (see ``docs`` folder).
 
 Maintainers
 ===========

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,6 @@ envlist =
     py27-{unix,windows}
     py36-{unix,windows}
     py37-{unix,windows}
-    py38-{unix,windows}
 
 [testenv]
 whitelist_externals =

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,10 @@
 [tox]
+skip_missing_interpreters = True
 envlist =
     py27-{unix,windows}
     py36-{unix,windows}
+    py37-{unix,windows}
+    py38-{unix,windows}
 
 [testenv]
 whitelist_externals =


### PR DESCRIPTION
Travis will now run multiple jobs in parallel to test against multiple python versions.
Current versions are 2.7, 3.6, 3.7, 3.8 (optimal).
EDIT: testing against py3.8-dev is probably unnecessary and delays the test result.
The `skip_missing_interpreters = True` option in the tox.ini allows contributors to run `tox` on their machine, as only existing python interpreters are used, while travis enforces tox to run on all.

There is a conditional deploy stage again, that is supposed to trigger when a commit with tag is detected, which doesn't come from a fork (no PR).
We've had problems with that before #254 so I'm not 100% sure that this will work as intended. We can always remove the repo and fork condition though, which should then definitely work. But until you trigger the next release, we won't know for sure.