### PR TITLE
Fix procmon on py27

### DIFF
--- a/boofuzz/pedrpc.py
+++ b/boofuzz/pedrpc.py
@@ -9,7 +9,7 @@ import select
 from . import exception
 
 
-class Client:
+class Client(object):
     def __init__(self, host, port):
         self.__host           = host
         self.__port           = port

--- a/boofuzz/utils/debugger_thread_simple.py
+++ b/boofuzz/utils/debugger_thread_simple.py
@@ -181,9 +181,8 @@ class DebuggerThreadSimple(threading.Thread):
         if self.isAlive():
             return True
         else:
-            rec_file = open(self.process_monitor.crash_filename, 'a')
-            rec_file.write(self.process_monitor.last_synopsis)
-            rec_file.close()
+            with open(self.process_monitor.crash_filename, 'a') as rec_file:
+                rec_file.write(self.process_monitor.last_synopsis.decode())
 
             if self.process_monitor.coredump_dir is not None:
                 dest = os.path.join(self.process_monitor.coredump_dir, str(self.process_monitor.test_number))


### PR DESCRIPTION
Some small patches to get the process monitor to run again.
There is still another issue preventing a connection when using py36, but that's something for another time.