### PR TITLE
Fixed type error on py36 under Windows

### DIFF
--- a/boofuzz/helpers.py
+++ b/boofuzz/helpers.py
@@ -121,7 +121,7 @@ def get_max_udp_size():
     if windows:
         sol_socket = ctypes.c_int(0xffff)
         sol_max_msg_size = 0x2003
-        lib = ctypes.WinDLL('Ws2_32.dll'.encode('ascii'))
+        lib = ctypes.WinDLL("Ws2_32.dll")
         opt = ctypes.c_int(sol_max_msg_size)
     elif linux or mac or openbsd:
         if mac:


### PR DESCRIPTION
Following error comes up when running boofuzz on python 3.6/Windows 10.
```cmd
C:\Users\admin\Documents\boofuzz\examples>python3.6 ftp-simple.py
Traceback (most recent call last):
  File "ftp-simple.py", line 49, in <module>
    main()
  File "ftp-simple.py", line 13, in main
    connection=SocketConnection("127.0.0.1", 80, proto='tcp')),
  File "c:\users\admin\documents\boofuzz\boofuzz\socket_connection.py", line 85, in __init__
    self.MAX_PAYLOADS["udp"] = helpers.get_max_udp_size()
  File "c:\users\admin\documents\boofuzz\boofuzz\helpers.py", line 123, in get_max_udp_size
    lib = ctypes.WinDLL('Ws2_32.dll'.encode('ascii'))
  File "C:\Users\admin\AppData\Local\Programs\Python\Python36\lib\ctypes\__init__.py", line 348, in __init__
    self._handle = _dlopen(self._name, mode)
TypeError: LoadLibrary() argument 1 must be str, not bytes
```
This fix is backward compatible to python 2.7
Too bad Travis doesn't support testing python under Windows.

Some references:
https://docs.python.org/3/library/ctypes.html#ctypes.WinDLL
The following were related to a similar error in python 2.7.13
https://github.com/pymedusa/Medusa/issues/1843
https://bugs.python.org/issue29082