### PR TITLE
Provide readme for pypi and changelog for docs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,10 +1,13 @@
+Changelog
+=========
+
 Upcoming
-========
+--------
 
 v0.1.5
-======
+------
 Features
---------
+^^^^^^^^
 - New curses logger class to provide a console gui similar to the webinterface. Use the session option `console_gui` to enable it.
   This has not been tested under Windows!
 - Compatibility for Python 3
@@ -17,14 +20,14 @@ Features
 - Process monitor in Windows will use `taskkill -F` if `taskkill` fails.
 
 Fixes
------
+^^^^^
 - Web server no longer crashes when asked for a non-existing test case.
 - EINPROGRESS socket error is now handled while opening a socket (note: this sometimes-transient error motivated the move to retry upon connection failure)
 
 v0.1.4
-======
+------
 Features
---------
+^^^^^^^^
 - New Session options `restart_callbacks`, `pre_send_callbacks`, and `post_test_case_callbacks` to hand over custom callback functions.
 - New Session option `fuzz_db_keep_only_n_pass_cases`. This allowes saving only n test cases preceding a failure or error to the database.
 - Added logic to find next available port for web interface or disable the web interface.
@@ -32,7 +35,7 @@ Features
 - Added option to reuse the connection to the target.
 
 Fixes
------
+^^^^^
 - Windows process monitor now handles combination of proc_name and/or start_commands more reasonably
 - Windows process monitor handles certain errors more gracefully
 - Fixed target close behavior so post send callbacks can use the target.
@@ -40,34 +43,34 @@ Fixes
 
 
 v0.1.3
-======
+------
 Features
---------
+^^^^^^^^
 - Socket Connections now allow client fuzzing.
 - Log only the data actually sent, when sending is truncated. Helps reduce database size, especially when fuzzing layer 2 or 3.
 - `Target` `recv` function now accepts a `max_recv_bytes` argument.
 
 Fixes
------
+^^^^^
 - Fixed install package -- now includes JavaScript files.
 
 v0.1.2
-======
+------
 Features
---------
+^^^^^^^^
 - Clearer error message when procmon is unavailable at fuzz start.
 - Web UI now refreshes current case even when snap-to-current-test-case is disabled.
 
 Fixes
------
+^^^^^
 - Web UI no longer permits negative test cases.
 - Fix Windows procmon regression.
 - Minor fixes and UI tweaks.
 
 v0.1.1
-======
+------
 Features
---------
+^^^^^^^^
 - New `boo open` command can open and inspect saved database log files.
 - Unix procmon now saves coredumps by default.
 - Improved "Cannot connect to target" error message.
@@ -75,14 +78,14 @@ Features
 - Made the global `REQUESTS` map available in top level boofuzz package.
 
 Fixes
------
+^^^^^
 - Handle exceptions when opening crash bin files in process monitor.
 - Fix Block.__len__ to account for custom encoder.
 
 v0.1.0
-======
+------
 Features
---------
+^^^^^^^^
 - Web UI
     - Statistics now auto-update.
     - Test case logs now stream on the main page.
@@ -92,13 +95,13 @@ Features
   invalid messages.
 
 Fixes
------
+^^^^^
 - Text log output would include double titles, e.g. "Test Step: Test Step: ..."
 
 v0.0.13
-=======
+-------
 Features
---------
+^^^^^^^^
 - Web UI
     - Test case numbers are now clickable and link to test case detail view.
     - Test case details now in color!
@@ -112,7 +115,7 @@ Features
     - procmon is now checked for errors before user ``post_send()`` is called, reducing redundant error messages.
     - Improved procmon logging.
     - Process monitor gives more helpful error messages when running 64-bit application (unsupported) or when a process is
-  killed before being attached
+      killed before being attached
 - Logging Improvements
     - ``Target`` ``open()`` and ``close()`` operations are now logged.
     - Added some optional debug output from boofuzz runtime.
@@ -129,7 +132,7 @@ Features
 
 
 Fixes
------
+^^^^^
 - Fixed bug in which failures were not recognized.
 - ``BitField`` blocks with ASCII format reported incorrect sizes.
 - Fixed bug in ``s_update``.
@@ -143,59 +146,59 @@ Fixes
 - Unix and Windows process monitors now share much more code.
 
 Development
------------
+^^^^^^^^^^^
 - Added unit tests for ``BitField``.
 - Cleaned up CSS on web pages.
 - Added a unit test to verify restart on failure behavior
 
 0.0.12
-======
+------
 Features
---------
+^^^^^^^^
 - Test cases now have descriptive names
 - Added Session methods to fuzz a test cae by name: ``fuzz_by_name`` and ``fuzz_single_node_by_path``
 
 Fixes
------
+^^^^^
 - Fixed test case numbers when using ``fuzz_single_case``
 
 0.0.11
-======
+------
 Features
---------
+^^^^^^^^
 -  Set Session ``check_data_received_each_request`` to False to disable receive after send.
 
 Fixes
------
+^^^^^
 -  Dosctring format fixes.
 
 0.0.10
-======
+------
 Features
---------
+^^^^^^^^
 -  Add Session ignore_connection_reset parameter to suppress ECONNRESET errors.
 -  Add Session ignore_connection_aborted parameter to suppress ECONNABORTED errors.
 
 Fixes
------
+^^^^^
 -  Fix Session class docstring formats.
 
 0.0.9
-=====
+-----
 Features
---------
+^^^^^^^^
 -  ``s_size`` is now fuzzable by default.
 -  Add new s_fuzz_list primitive to read fuzz value from files.
 -  Add new FuzzLoggerCsv to write log in CSV format 
 
 Fixes
------
+^^^^^
 -  Fixed: Add missing dummy value for custom checksum, allowing recursive uses of length/checksum (issue #107)
 
 0.0.8
-=====
+-----
 Features
---------
+^^^^^^^^
 -  Console output - now with colors!
 -  process_monitor_unix.py: added option to move coredumps for later analysis.
 -  The process monitor (procmon) now tracks processes by PID by default rather than searching by name. Therefore,
@@ -209,7 +212,7 @@ Features
 -  Added example fuzz scripts.
 
 Fixes
------
+^^^^^
 -  SIGINT (AKA Ctrl+C) now works to close both boofuzz and process_monitor.py (usually).
 -  Fixed: The pedrpc module was not being properly included in imports.
 -  Made process_monitor.py ``--crash_bin`` optional (as documented).
@@ -218,20 +221,20 @@ Fixes
 -  Fixed a bug in which the procmon would not properly restart a target that had failed without crashing.
 
 0.0.7
-=====
+-----
 Features
---------
+^^^^^^^^
 -  Added several command injection strings from fuzzdb.
 -  Blocks can now be created and nested using ``with s_block("my-block"):``
 
 Fixes
------
+^^^^^
 -  Fixed pydot import error message
 
 0.0.6
-=====
+-----
 Features
---------
+^^^^^^^^
 -  Added ``Request.original_value()`` function to render the request as if it were not fuzzed.
    This will help enable reuse of a fuzz definition to generate valid requests.
 -  ``SocketConnection`` can now send and receive UDP broadcast packets using the ``udp_broadcast`` constructor
@@ -239,7 +242,7 @@ Features
 -  ``Target.recv()`` now logs an entry before receiving data, in order to help debug receiving issues.
 
 Fixes
------
+^^^^^
 -  Maximum UDP payload value was incorrect, causing crashes for tests running over UDP. It now works on some systems,
    but the maximum value may be too high for systems that set it lower than the maximum possible value, 65507.
 -  ``SocketConnection`` class now handles more send and receive errors:  ``ECONNABORTED``, ``ECONNRESET``,
@@ -247,14 +250,14 @@ Fixes
 -  Fixed setup.py to not include superfluous packages.
 
 Development
------------
+^^^^^^^^^^^
 -  Added two exceptions: ``BoofuzzTargetConnectionReset`` and ``BoofuzzTargetConnectionAborted``.
 -  These two exceptions are handled in ``sessions.py`` and may be thrown by any ``ITargetConnection`` implementation.
 
 0.0.5
-=====
-Fixes
 -----
+Fixes
+^^^^^
 -  Boofuzz now properly reports crashes detected by the process monitor. It was calling log_info instead of log_fail.
 -  Boofuzz will no longer crash, but will rather give a helpful error message, if the target refuses socket connections.
 -  Add utils/crash_binning.py to boofuzz/utils, avoiding import errors.
@@ -262,55 +265,55 @@ Fixes
 -  Fix typos in INSTALL.rst.
 
 0.0.4
-=====
+-----
 -  Add Gitter badge to README.
 -  Add default sleep_time and fuzz_data_logger for Session to simplify boilerplate.
 
 0.0.3
-=====
+-----
 -  Fixed deployment from 0.0.2.
 -  Simplify CONTRIBUTING.rst for automated deployment.
 -  tox no longer runs entirely as sudo. The sudo has been moved into tox.ini and is more fine-grained.
 -  Reduced default ``Session.__init__`` ``restart_sleep_time`` from 5 minutes to 5 seconds.
 
 0.0.2
-=====
+-----
 Continuous deployment with Travis.
 
 Development
------------
+^^^^^^^^^^^
 -  Added build and PyPI badges.
 -  Added CONTRIBUTING.rst.
 -  check-manifest now runs in automated build.
 -  Travis now deploys to PyPI!
 
 0.0.1-dev5
-==========
+----------
 Development
------------
+^^^^^^^^^^^
 -  Tests now run on tox.
 -  Added Google Groups and Twitter link.
 
 0.0.1-dev4
-==========
+----------
 
 Fixes
------
+^^^^^
 -  Missing property setters in ``boofuzz.request.Request`` now implemented.
 -  Unit tests now pass on Windows.
 -  Fixed wheel build issue; boofuzz subpackages were missing.
 
 0.0.1-dev3
-==========
+----------
 
 Fixes
------
+^^^^^
 -  Session constructor param ``session_filename`` is now optional.
 
 0.0.1-dev2
-==========
+----------
 New features
-------------
+^^^^^^^^^^^^
 
 -  Now on PyPI! ``pip install boofuzz``
 -  API is now centralized so all classes are available at top level
@@ -323,14 +326,14 @@ New features
    ezOutlet EZ-11b.
 
 Backwards-incompatible
-----------------------
+^^^^^^^^^^^^^^^^^^^^^^
 
 -  Target now only takes an ``ITargetConnection``. This separates
    responsibilities and makes our code more flexible with different
    kinds of connections.
 
 Fixes
------
+^^^^^
 
 -  Bugs fixed:
 
@@ -345,7 +348,7 @@ Fixes
       properly.
 
 Back-end Improvements
----------------------
+^^^^^^^^^^^^^^^^^^^^^
 
 This section took the most work. It has the least visible impact, but
 all of the refactors enable new features, fixes, and unit tests.
@@ -362,14 +365,14 @@ all of the refactors enable new features, fixes, and unit tests.
 -  Many Unit tests added.
 
 Other
------
+^^^^^
 
 -  Continuous integration with Travis is running!
 -  Doc organization improvements.
 -  Can now install with extras ``[dev]``
 
 Initial Development Release - 0.0.1-dev1
-========================================
+----------------------------------------
 
 
 -  Much easier install experience!

--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ Boofuzz is a fork of and the successor to the venerable `Sulley`_ fuzzing
 framework. Besides numerous bug fixes, boofuzz aims for extensibility.
 The goal: fuzz everything.
 
-.. figure:: _static/boofuzz-screenshot.png
+.. figure:: https://github.com/jtpereyda/boofuzz/raw/master/_static/boofuzz-screenshot.png
     :alt: boofuzz screenshot
 
 Why?
@@ -50,7 +50,7 @@ Sulley is affectionately named after the giant teal and purple creature
 from Monsters Inc. due to his fuzziness. Boofuzz is likewise named after
 the only creature known to have scared Sulley himself: Boo!
 
-.. figure:: _static/boo.png
+.. figure:: https://github.com/jtpereyda/boofuzz/raw/master/_static/boo.png
    :alt: Boo from Monsters Inc
 
    Boo from Monsters Inc

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -73,6 +73,11 @@ User Guide
     user/quickstart
     user/contributing
 
+.. toctree::
+    :maxdepth: 1
+
+    user/changelog
+
 Public Protocol Libraries
 -------------------------
 

--- a/docs/user/changelog.rst
+++ b/docs/user/changelog.rst
@@ -1,0 +1,2 @@
+.. _changelog:
+.. include:: ../../CHANGELOG.rst

--- a/docs/user/logging.rst
+++ b/docs/user/logging.rst
@@ -35,6 +35,13 @@ CSV Logging
     :undoc-members:
     :show-inheritance:
 
+Console-GUI Logging
+===================
+.. autoclass:: boofuzz.FuzzLoggerCurses
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
 File Logging
 ============
 Deprecated: Use FuzzLogger with FuzzLoggerText for typical fuzz logging.

--- a/setup.py
+++ b/setup.py
@@ -23,9 +23,17 @@ def find_version(*path_elements):
     raise RuntimeError("version string not found in {0}".format(path))
 
 
+def get_long_description():
+    with open(os.path.join(setup_dir, 'README.rst'), encoding='utf-8') as f:
+        return f.read()
+
+
 setup(
         name='boofuzz',
         version=find_version("boofuzz", "__init__.py"),
+        description="A fork and successor of the Sulley Fuzzing Framework",
+        long_description=get_long_description(),
+        long_description_content_type='text/x-rst',
         maintainer='Joshua Pereyda',
         maintainer_email='joshua.t.pereyda@gmail.com',
         url='https://github.com/jtpereyda/boofuzz',

--- a/setup.py
+++ b/setup.py
@@ -24,8 +24,11 @@ def find_version(*path_elements):
 
 
 def get_long_description():
-    with open(os.path.join(setup_dir, 'README.rst'), encoding='utf-8') as f:
-        return f.read()
+    descr = []
+    for fname in 'README.rst', 'CHANGELOG.rst':
+        with open(os.path.join(setup_dir, fname), encoding='utf-8') as f:
+            descr.append(f.read())
+    return '\n\n'.join(descr)
 
 
 setup(


### PR DESCRIPTION
- Changed the setup.py so that PyPi should now show the readme ([Docs](https://packaging.python.org/guides/making-a-pypi-friendly-readme/))
Appending the changelog below the readme would work too - up to you.
- Added the changelog to the documentation, which required changing the headline levels
- Added FuzzLoggerCurses to the documentation
