### PR TITLE
Fixed socket exception handling

### DIFF
--- a/boofuzz/socket_connection.py
+++ b/boofuzz/socket_connection.py
@@ -158,7 +158,7 @@ class SocketConnection(itarget_connection.ITargetConnection):
                 self._sock.connect((self.host, self.port))
             except socket.error as e:
                 if e.errno in [errno.ECONNREFUSED, errno.EINPROGRESS]:
-                    raise exception.BoofuzzTargetConnectionFailedError(e.message)
+                    raise exception.BoofuzzTargetConnectionFailedError(str(e))
                 else:
                     raise
 
@@ -205,7 +205,7 @@ class SocketConnection(itarget_connection.ITargetConnection):
             elif (e.errno == errno.ECONNRESET) or \
                     (e.errno == errno.ENETRESET) or \
                     (e.errno == errno.ETIMEDOUT):
-                raise_(exception.BoofuzzTargetConnectionReset, None, sys.exc_info()[2])
+                raise_(exception.BoofuzzTargetConnectionReset(), None, sys.exc_info()[2])
             elif e.errno == errno.EWOULDBLOCK:  # timeout condition if using SO_RCVTIMEO or SO_SNDTIMEO
                 data = six.binary_type(b'')
             else:
@@ -264,7 +264,7 @@ class SocketConnection(itarget_connection.ITargetConnection):
                     (e.errno == errno.ENETRESET) or \
                     (e.errno == errno.ETIMEDOUT) or \
                     (e.errno == errno.EPIPE):
-                raise_(exception.BoofuzzTargetConnectionReset, None, sys.exc_info()[2])
+                raise_(exception.BoofuzzTargetConnectionReset(), None, sys.exc_info()[2])
             else:
                 raise
         return num_sent


### PR DESCRIPTION
Addressing #281

- Python 3 doesn't have `e.message` so we use `str(e)` which does just the same.

- When using `raise_` from future.utils and not passing any arguments, we still have to call it with parentheses.