### PR TITLE
close test case in check_message()

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,11 @@
 Upcoming
 ========
+Features
+--------
+
+Fixes
+-----
+- Test cases were not being properly closed when using the check_message() functionality.
 
 v0.1.5
 ======

--- a/boofuzz/sessions.py
+++ b/boofuzz/sessions.py
@@ -1376,6 +1376,7 @@ class Session(pgraph.Graph):
             else:
                 print("PASS: {0}".format(test_case_name))
             self._stop_netmon(target)
+            self._fuzz_data_logger.close_test_case()
             self.export_file()
 
     def _fuzz_current_case(self, path):


### PR DESCRIPTION
Patch -- close_test_case() was being called when fuzzing but not when running check_message()