### PR TITLE
Check also timeout when opening TCP connection

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ Features
 Fixes
 ^^^^^
 - Test cases were not being properly closed when using the check_message() functionality.
+- Timeout during opening TCP connection now raises BoofuzzTargetConnectionFailedError exception.
 
 v0.1.5
 ------

--- a/boofuzz/socket_connection.py
+++ b/boofuzz/socket_connection.py
@@ -157,7 +157,7 @@ class SocketConnection(itarget_connection.ITargetConnection):
             try:
                 self._sock.connect((self.host, self.port))
             except socket.error as e:
-                if e.errno in [errno.ECONNREFUSED, errno.EINPROGRESS]:
+                if e.errno in [errno.ECONNREFUSED, errno.EINPROGRESS, errno.ETIMEDOUT]:
                     raise exception.BoofuzzTargetConnectionFailedError(str(e))
                 else:
                     raise


### PR DESCRIPTION
When Boofuzz is opening TCP connection and the target is (temporarily) unreachable, Boofuzz crash with the following error:

![image](https://user-images.githubusercontent.com/2153835/59035221-19f7e500-886d-11e9-8f5b-24e83a1929f6.png)


I suggest that `SocketConnection.open()` should throw `BoofuzzTargetConnectionFailedError` in this case.