### PR TITLE
Do not ignore empty default value in s_group

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ Features
 Fixes
 ^^^^^
 - Test cases were not being properly closed when using the check_message() functionality.
+- `s_group` primitive was not accepting empty default value.
 
 v0.1.5
 ------

--- a/boofuzz/primitives/group.py
+++ b/boofuzz/primitives/group.py
@@ -24,6 +24,8 @@ class Group(BasePrimitive):
 
         assert len(self.values) > 0, "You can't have an empty value list for your group!"
 
+        if default_value is None:
+            default_value = self.values[0]
         self._value = self._original_value = default_value
 
         for val in self.values:

--- a/boofuzz/primitives/group.py
+++ b/boofuzz/primitives/group.py
@@ -24,8 +24,6 @@ class Group(BasePrimitive):
 
         assert len(self.values) > 0, "You can't have an empty value list for your group!"
 
-        if not default_value:
-            default_value = self.values[0]
         self._value = self._original_value = default_value
 
         for val in self.values:


### PR DESCRIPTION
Hi,

I think that an empty string as the default value for `s_group` should be valid.

Or is there any reason, why to replace it for the first value from possible values?