### PR TITLE
Fixed concatenation of bytes in PED-RPC

### DIFF
--- a/boofuzz/pedrpc.py
+++ b/boofuzz/pedrpc.py
@@ -133,7 +133,7 @@ class Client(object):
             return
 
         try:
-            received = ""
+            received = b""
 
             while length:
                 chunk = self.__server_sock.recv(length)
@@ -213,7 +213,7 @@ class Server(object):
 
         try:
             length = struct.unpack("<L", self.__client_sock.recv(4))[0]
-            received = ""
+            received = b""
 
             while length:
                 chunk = self.__client_sock.recv(length)


### PR DESCRIPTION
On Python3, socket.recv returns bytes. Concatenating bytes to str results
in TypeError.

```
TypeError: can only concatenate str (not "bytes") to str
```