### PR TITLE
Updated gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,58 @@
-*.pyc
-archived_fuzzies/*.session
-docs/_build/
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# Distribution / packaging
+.Python
 build/
+develop-eggs/
 dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+pip-wheel-metadata/
+share/python-wheels/
 *.egg-info/
-.idea/
-testing/
+.installed.cfg
+*.egg
+MANIFEST
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.nox/
+.coverage
+.coverage.*
 .cache
-.tox
+nosetests.xml
+coverage.xml
+*.cover
+.hypothesis/
+.pytest_cache/
+testing/
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/
+
+# Sphinx documentation
+docs/_build/
+
+# PyCharm
+.idea/
+
+# Misc
+archived_fuzzies/*.session
 boofuzz-results/


### PR DESCRIPTION
After updating my system to Ubuntu 19.04, Python3.7 and pip 19.2.1 I noticed a `pip-wheel-metadata` folder appearing. Might be because of tox.
So I used the circumstances to rewrite the .gitignore using this [template](https://github.com/github/gitignore/blob/master/Python.gitignore).

There are some exclusions that are probably not need at the moment, but I guess it doesn't hurt having them and it makes this a little more future proof.