### PR TITLE
Fixed and documented boo open

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ Fixes
 - Timeout during opening TCP connection now raises BoofuzzTargetConnectionFailedError exception.
 - Dropped six.binary_type in favor of b"" format
 - Fixed process monitor handling of backslashes in Windows start commands
+- Fixed and documented `boo open`
 
 v0.1.5
 ------

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -21,3 +21,5 @@ recursive-include docs Makefile
 
 recursive-include _static *.png
 recursive-include docs *.png
+
+prune docs/_build

--- a/boofuzz/sessions.py
+++ b/boofuzz/sessions.py
@@ -217,7 +217,7 @@ class SessionInfo(object):
 
     @property
     def total_mutant_index(self):
-        x = self._db_reader.query("""SELECT COUNT(*) FROM cases""").next()[0]
+        x = next(self._db_reader.query("SELECT COUNT(*) FROM cases"))[0]
         return x
 
     def test_case_data(self, index):

--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -65,7 +65,7 @@ current workdir. You can reopen the webinterface on any of those databases at an
     boo open <run-*.db>
 
 To do cool stuff like checking responses, you'll want to use ``post_test_case_callbacks`` in
-:class:`Session <boofuzz.Session>`. You may also want be interested in :ref:`custom-blocks`.
+:class:`Session <boofuzz.Session>`. You may also be interested in :ref:`custom-blocks`.
 
 Remember boofuzz is all Python, so everything is there for your customization.
 If you are doing crazy cool stuff, check out the :ref:`community info <community>` and consider contributing back!

--- a/docs/user/quickstart.rst
+++ b/docs/user/quickstart.rst
@@ -4,7 +4,8 @@ Quickstart
 ==========
 
 The :class:`Session <boofuzz.Session>` object is the center of your fuzz... session. When you create it,
-you'll pass it a :class:`Target <boofuzz.Target>` object, which will itself receive a :ref:`Connection <connections>` object. For example: ::
+you'll pass it a :class:`Target <boofuzz.Target>` object, which will itself receive a :ref:`Connection <connections>`
+object. For example: ::
 
     session = Session(
         target=Target(
@@ -58,8 +59,13 @@ After that, you are ready to fuzz: ::
 
 Note that at this point you have only a very basic fuzzer. Making it kick butt is up to you.
 
-To do cool stuff like checking responses, you'll want to use :meth:`Session.post_send <boofuzz.Session.post_send>`.
-You may also want be interested in :ref:`custom-blocks`.
+The log data of each run will be saved to a SQLite database located in the **boofuzz-results** directory at your
+current workdir. You can reopen the webinterface on any of those databases at any time with::
+
+    boo open <run-*.db>
+
+To do cool stuff like checking responses, you'll want to use ``post_test_case_callbacks`` in
+:class:`Session <boofuzz.Session>`. You may also want be interested in :ref:`custom-blocks`.
 
 Remember boofuzz is all Python, so everything is there for your customization.
 If you are doing crazy cool stuff, check out the :ref:`community info <community>` and consider contributing back!


### PR DESCRIPTION
`boo open` was broken in Python3.7, works now.
```python
AttributeError: 'sqlite3.Cursor' object has no attribute 'next'
```
#256 indicated that `boo open` is not documented, so I added a short description to the Quickstart page.

When building the docs locally, I noticed that tox fails when the docs/_build dir still exists. Added a ignore for it to the MENIFEST.in to fix this.