### PR TITLE
Fixed receive function in fuzz_logger_curses

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ Fixes
 - Timeout during opening TCP connection now raises BoofuzzTargetConnectionFailedError exception.
 - Dropped six.binary_type in favor of b"" format
 - Fixed process monitor handling of backslashes in Windows start commands
+- Fixed receive function in `fuzz_logger_curses`
 
 v0.1.5
 ------

--- a/boofuzz/fuzz_logger_curses.py
+++ b/boofuzz/fuzz_logger_curses.py
@@ -183,7 +183,7 @@ class FuzzLoggerCurses(ifuzz_logger_backend.IFuzzLoggerBackend):
         self._event_log = True
 
     def log_recv(self, data):
-        self._log_storage.append(helpers.format_log_msg(msg_type="recv", data=data, format_type="curses"))
+        self._log_storage.append(helpers.format_log_msg(msg_type="receive", data=data, format_type="curses"))
         self._event_log = True
 
     def log_send(self, data):


### PR DESCRIPTION
The curses logger uses the wrong `msg_type` for received messages.
https://github.com/jtpereyda/boofuzz/blob/473190604da004ca952616005861c4c0abfa3cf6/boofuzz/helpers.py#L63-L70