### PR TITLE
Disabled stickler fixers

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -1,10 +1,10 @@
 fixers:
-  enable: true
+  enable: false
 
 linters:
   black:
     config: ./pyproject.toml
-    fixer: true
+    fixer: false
   flake8:
     config: ./setup.cfg
-    fixer: true
+    fixer: false


### PR DESCRIPTION
Temporarily disable stickler fixers as missing push permissions on the fork will result in false positive checks.
See https://github.com/jtpereyda/boofuzz/issues/304#issuecomment-520495330