### PR TITLE
Add s_numbers primitive

### DIFF
--- a/boofuzz/__init__.py
+++ b/boofuzz/__init__.py
@@ -797,7 +797,7 @@ def s_qword(
 
 
 def s_numbers(
-    value, size=-1, max_num=None, signed=False, fuzzable=True, name=None
+    value, max_len=-1, padding=" ", signed=True, fuzzable=True, name=None
 ):
     """ 
     The bit field primitive represents a number of variable length and is used to define all other integer types.
@@ -816,7 +816,7 @@ def s_numbers(
     @param name:          (Optional, def=None) Specifying a name gives you direct access to a primitive
     """
 
-    numbers = primitives.Numbers(value, size, max_num, signed, fuzzable, name)
+    numbers = primitives.Numbers(value, max_len, padding, signed, fuzzable, name)
     blocks.CURRENT.push(numbers)
 
 

--- a/boofuzz/__init__.py
+++ b/boofuzz/__init__.py
@@ -796,10 +796,8 @@ def s_qword(
     blocks.CURRENT.push(qword)
 
 
-def s_numbers(
-    value, max_len=-1, padding=" ", signed=True, fuzzable=True, name=None
-):
-    """ 
+def s_numbers(value, max_len=-1, padding=" ", signed=True, fuzzable=True, name=None):
+    """
     The bit field primitive represents a number of variable length and is used to define all other integer types.
 
     @type  value:         str

--- a/boofuzz/__init__.py
+++ b/boofuzz/__init__.py
@@ -797,7 +797,7 @@ def s_qword(
 
 
 def s_numbers(
-    value, size=-1, max_num=None, signed=False, fuzzable=True, name=None,
+    value, size=-1, max_num=None, signed=False, fuzzable=True, name=None
 ):
     """ 
     The bit field primitive represents a number of variable length and is used to define all other integer types.

--- a/boofuzz/__init__.py
+++ b/boofuzz/__init__.py
@@ -798,7 +798,7 @@ def s_qword(
 
 def s_numbers(value, max_len=-1, padding=" ", signed=True, fuzzable=True, name=None):
     """
-    The bit field primitive represents a number of variable length and is used to define all other integer types.
+    Push potentially conflictive numbers onto the current block stack.
 
     @type  value:         str
     @param value:         Default number value

--- a/boofuzz/__init__.py
+++ b/boofuzz/__init__.py
@@ -31,6 +31,7 @@ from .primitives import (
     Static,
     String,
     Word,
+    Numbers,
 )
 from .serial_connection import SerialConnection
 from .sessions import open_test_run, Session, Target
@@ -62,6 +63,7 @@ __all__ = [
     "LITTLE_ENDIAN",
     "Mirror",
     "MustImplementException",
+    "Numbers",
     "open_test_run",
     "pedrpc",
     "primitives",
@@ -98,6 +100,7 @@ __all__ = [
     "s_mirror",
     "s_mutate",
     "s_num_mutations",
+    "s_numbers",
     "s_qword",
     "s_random",
     "s_raw",
@@ -791,6 +794,30 @@ def s_qword(
 
     qword = primitives.QWord(value, endian, output_format, signed, full_range, fuzzable, name)
     blocks.CURRENT.push(qword)
+
+
+def s_numbers(
+    value, size=-1, max_num=None, signed=False, fuzzable=True, name=None,
+):
+    """ 
+    The bit field primitive represents a number of variable length and is used to define all other integer types.
+
+    @type  value:         str
+    @param value:         Default number value
+    @type  size:          int
+    @param size:          (Optional, def=-1) Static size of this field, leave -1 for dynamic.
+    @type  max_num:       int
+    @param max_num:       Maximum number to iterate up to
+    @type  signed:        bool
+    @param signed:        (Optional, def=False) Make size signed vs. unsigned
+    @type  fuzzable:      bool
+    @param fuzzable:      (Optional, def=True) Enable/disable fuzzing of this primitive
+    @type  name:          str
+    @param name:          (Optional, def=None) Specifying a name gives you direct access to a primitive
+    """
+
+    numbers = primitives.Numbers(value, size, max_num, signed, fuzzable, name)
+    blocks.CURRENT.push(numbers)
 
 
 # ALIASES

--- a/boofuzz/__init__.py
+++ b/boofuzz/__init__.py
@@ -800,18 +800,18 @@ def s_numbers(value, max_len=-1, padding=" ", signed=True, fuzzable=True, name=N
     """
     Push potentially conflictive numbers onto the current block stack.
 
-    @type  value:         str
-    @param value:         Default number value
-    @type  size:          int
-    @param size:          (Optional, def=-1) Static size of this field, leave -1 for dynamic.
-    @type  max_num:       int
-    @param max_num:       Maximum number to iterate up to
-    @type  signed:        bool
-    @param signed:        (Optional, def=False) Make size signed vs. unsigned
-    @type  fuzzable:      bool
-    @param fuzzable:      (Optional, def=True) Enable/disable fuzzing of this primitive
-    @type  name:          str
-    @param name:          (Optional, def=None) Specifying a name gives you direct access to a primitive
+    :type  value:         str
+    :param value:         Default number value
+    :type  size:          int
+    :param size:          (Optional, def=-1) Static size of this field, leave -1 for dynamic.
+    :type  max_num:       int
+    :param max_num:       Maximum number to iterate up to
+    :type  signed:        bool
+    :param signed:        (Optional, def=False) Make size signed vs. unsigned
+    :type  fuzzable:      bool
+    :param fuzzable:      (Optional, def=True) Enable/disable fuzzing of this primitive
+    :type  name:          str
+    :param name:          (Optional, def=None) Specifying a name gives you direct access to a primitive
     """
 
     numbers = primitives.Numbers(value, max_len, padding, signed, fuzzable, name)

--- a/boofuzz/primitives/__init__.py
+++ b/boofuzz/primitives/__init__.py
@@ -12,6 +12,7 @@ from .random_data import RandomData
 from .static import Static
 from .string import String
 from .word import Word
+from .numbers import Numbers
 
 __all__ = [
     "BasePrimitive",
@@ -27,4 +28,5 @@ __all__ = [
     "Static",
     "String",
     "Word",
+    "Numbers",
 ]

--- a/boofuzz/primitives/numbers.py
+++ b/boofuzz/primitives/numbers.py
@@ -1,18 +1,8 @@
-import six
-
 from .base_primitive import BasePrimitive
-from .. import helpers
 
 
 class Numbers(BasePrimitive):
-    def __init__(self,
-        value,
-        max_len=-1,
-        padding="",
-        signed=False,
-        fuzzable=True,
-        name=None,
-    ):
+    def __init__(self, value, max_len=-1, padding="", signed=False, fuzzable=True, name=None):
         """
         Primitive that cycles through a library of "bad" numbers, represented as strings.
 
@@ -21,7 +11,7 @@ class Numbers(BasePrimitive):
         @type  max_len:       int
         @param max_len:       (Optional, def=-1) Max length of strings returned, leave -1 for any length
         @type  padding:       str
-        @param padding:       (Optional, def="") Return strings left-padded with this string, for use with max_len. Default is " "
+        @param padding:       (Optional, def="") String for left-padding, for use with max_len. Default is " "
         @type  signed:        bool
         @param signed:        (Optional, def=False) Make size signed vs. unsigned
         @type  fuzzable:      bool
@@ -37,61 +27,61 @@ class Numbers(BasePrimitive):
         self.signed = signed
         self._fuzzable = fuzzable
         self._name = name
-        
+
         nums = [
-                # taken from https://github.com/minimaxir/big-list-of-naughty-strings
-                "0",
-                "1",
-                "1.00",
-                "$1.00",
-                "1/2",
-                "1E2",
-                "1E02",
-                "1E+02",
-                "1/0",
-                "0/0",
-                "0.00",
-                "0..0",
-                ".",
-                "0.0.0",
-                "0,00",
-                "0,,0",
-                ",",
-                "0,0,0",
-                "0.0/0",
-                "1.0/0.0",
-                "0.0/0.0",
-                "1,0/0,0",
-                "0,0/0,0",
-                "999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999",
-                "NaN",
-                "Infinity",
-                "INF",
-                "1#INF",
-                "1#QNAN",
-                "1#SNAN",
-                "1#IND",
-                "0x0",
-                "0xffffffff",
-                "0xffffffffffffffff",
-                "0xabad1dea",
-                "123456789012345678901234567890123456789",
-                "1,000.00",
-                "1 000.00",
-                "1'000.00",
-                "1,000,000.00",
-                "1 000 000.00",
-                "1'000'000.00",
-                "1.000,00",
-                "1 000,00",
-                "1'000,00",
-                "1.000.000,00",
-                "1 000 000,00",
-                "1'000'000,00",
-                "01000",
-                "08",
-                "09",
-                "2.2250738585072011e-308",
+            # taken from https://github.com/minimaxir/big-list-of-naughty-strings
+            "0",
+            "1",
+            "1.00",
+            "$1.00",
+            "1/2",
+            "1E2",
+            "1E02",
+            "1E+02",
+            "1/0",
+            "0/0",
+            "0.00",
+            "0..0",
+            ".",
+            "0.0.0",
+            "0,00",
+            "0,,0",
+            ",",
+            "0,0,0",
+            "0.0/0",
+            "1.0/0.0",
+            "0.0/0.0",
+            "1,0/0,0",
+            "0,0/0,0",
+            "999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999",
+            "NaN",
+            "Infinity",
+            "INF",
+            "1#INF",
+            "1#QNAN",
+            "1#SNAN",
+            "1#IND",
+            "0x0",
+            "0xffffffff",
+            "0xffffffffffffffff",
+            "0xabad1dea",
+            "123456789012345678901234567890123456789",
+            "1,000.00",
+            "1 000.00",
+            "1'000.00",
+            "1,000,000.00",
+            "1 000 000.00",
+            "1'000'000.00",
+            "1.000,00",
+            "1 000,00",
+            "1'000,00",
+            "1.000.000,00",
+            "1 000 000,00",
+            "1'000'000,00",
+            "01000",
+            "08",
+            "09",
+            "2.2250738585072011e-308",
         ]
 
         signed_nums = [
@@ -127,12 +117,11 @@ class Numbers(BasePrimitive):
                         len_pad = len(padding)
                         n_pad = total_pad // len_pad
                         r_pad = total_pad % len_pad
-                        self._fuzz_library.append(padding*n_pad + padding[:r_pad] + v)
+                        self._fuzz_library.append(padding * n_pad + padding[:r_pad] + v)
                     else:
-                        self._fuzz_library.append(" "*total_pad + v)
+                        self._fuzz_library.append(" " * total_pad + v)
             else:
                 self._fuzz_library = val_list
-
 
     @property
     def name(self):

--- a/boofuzz/primitives/numbers.py
+++ b/boofuzz/primitives/numbers.py
@@ -1,0 +1,150 @@
+import six
+
+from .base_primitive import BasePrimitive
+from .. import helpers
+
+
+class Numbers(BasePrimitive):
+    def __init__(self,
+        value,
+        size=-1,
+        max_num=None,
+        signed=False,
+        fuzzable=True,
+        name=None,
+    ):
+        """
+        Primitive that cycles through a library of "bad" numbers, represented as strings.
+
+        @type  value:         str
+        @param value:         Default number value
+        @type  size:          int
+        @param size:          (Optional, def=-1) Static size of this field, leave -1 for dynamic.
+        @type  max_num:       int
+        @param max_num:       Maximum number to iterate up to
+        @type  signed:        bool
+        @param signed:        (Optional, def=False) Make size signed vs. unsigned
+        @type  fuzzable:      bool
+        @param fuzzable:      (Optional, def=True) Enable/disable fuzzing of this primitive
+        @type  name:          str
+        @param name:          (Optional, def=None) Specifying a name gives you direct access to a primitive
+        """
+
+        super(Numbers, self).__init__()
+
+        self._value = self._original_value = value
+        self.size = size
+        self.max_num = max_num
+        self.signed = signed
+        self._fuzzable = fuzzable
+        self._name = name
+
+        if not self._fuzz_library:
+            self._fuzz_library = [
+                # taken from https://github.com/minimaxir/big-list-of-naughty-strings
+                "0",
+                "1",
+                "1.00",
+                "$1.00",
+                "1/2",
+                "1E2",
+                "1E02",
+                "1E+02",
+                "1/0",
+                "0/0",
+                "0.00",
+                "0..0",
+                ".",
+                "0.0.0",
+                "0,00",
+                "0,,0",
+                ",",
+                "0,0,0",
+                "0.0/0",
+                "1.0/0.0",
+                "0.0/0.0",
+                "1,0/0,0",
+                "0,0/0,0",
+                "999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999",
+                "NaN",
+                "Infinity",
+                "INF",
+                "1#INF",
+                "1#QNAN",
+                "1#SNAN",
+                "1#IND",
+                "0x0",
+                "0xffffffff",
+                "0xffffffffffffffff",
+                "0xabad1dea",
+                "123456789012345678901234567890123456789",
+                "1,000.00",
+                "1 000.00",
+                "1'000.00",
+                "1,000,000.00",
+                "1 000 000.00",
+                "1'000'000.00",
+                "1.000,00",
+                "1 000,00",
+                "1'000,00",
+                "1.000.000,00",
+                "1 000 000,00",
+                "1'000'000,00",
+                "01000",
+                "08",
+                "09",
+                "2.2250738585072011e-308",
+            ]
+            signed_nums = [
+                "-1",
+                "-1.00",
+                "-$1.00",
+                "-1/2",
+                "-1E2",
+                "-1E02",
+                "-1E+02",
+                "-2147483648/-1",
+                "-9223372036854775808/-1",
+                "-0",
+                "-0.0",
+                "+0",
+                "+0.0",
+                "--1",
+                "-",
+                "-.",
+                "-,",
+                "-Infinity",
+                "-1#IND",
+            ]
+
+            if signed:
+                for num in signed_nums:
+                    self._fuzz_library.append(num)
+
+            bits = 64
+            while bits != 0:
+                self._fuzz_library.append(str(1 << bits))
+                self._fuzz_library.append(str((1 << bits) + 1))
+                self._fuzz_library.append(str((1 << bits) - 1))
+                if signed:
+                    self._fuzz_library.append(str(-(1 << bits)))
+                    self._fuzz_library.append(str(-(1 << bits) + 1))
+                    self._fuzz_library.append(str(-(1 << bits) - 1))
+                bits = bits // 2
+
+    @property
+    def name(self):
+        return self._name
+
+    def _render(self, value):
+        """
+        Render string value, properly padded.
+        """
+
+        if isinstance(value, six.text_type):
+            value = helpers.str_to_bytes(value)
+
+        # pad undersized library items.
+        if len(value) < self.size:
+            value += self.padding * (self.size - len(value))
+        return helpers.str_to_bytes(value)


### PR DESCRIPTION
The idea is to use a list of numbers that may cause errors in, say, web applications, or even find bugs and vulnerabilities such as division by zero, integer overflows and similar.

I took most of these from the [Big List of Naughty Strings](https://github.com/minimaxir/big-list-of-naughty-strings) repo, and then some [data type limits](
https://en.wikipedia.org/wiki/Magic_number_(programming)#Data_type_limits).

Similarly to https://github.com/jtpereyda/boofuzz/pull/302, you can test this primitive by running `while [ True ]; do nc -w 1 127.0.0.1 12345; echo; done` in one console and the following code in python:
```from boofuzz import *
session = Session( target=Target( connection=SocketConnection( host="127.0.0.1", port=12345, proto='tcp', server=True ),),)
s_initialize("A")
s_numbers("0")
session.connect(session.root, s_get("A"))
session.fuzz()
```