### PR TITLE
Add s_integers primitive and Integers class

### DIFF
--- a/boofuzz/__init__.py
+++ b/boofuzz/__init__.py
@@ -25,6 +25,7 @@ from .primitives import (
     DWord,
     FromFile,
     Group,
+    Integers,
     Mirror,
     QWord,
     RandomData,
@@ -57,6 +58,7 @@ __all__ = [
     "Group",
     "IFuzzLogger",
     "IFuzzLoggerBackend",
+    "Integers",
     "ITargetConnection",
     "legos",
     "LITTLE_ENDIAN",
@@ -92,6 +94,7 @@ __all__ = [
     "s_hex_dump",
     "s_initialize",
     "s_int",
+    "s_integers",
     "s_intelword",
     "s_lego",
     "s_long",
@@ -791,6 +794,28 @@ def s_qword(
 
     qword = primitives.QWord(value, endian, output_format, signed, full_range, fuzzable, name)
     blocks.CURRENT.push(qword)
+
+
+def s_integers(value, bits=128, max_num=None, signed=True, fuzzable=True, name=None):
+    """
+    Push variable length integers onto the current block stack.
+
+    :type  value:          int
+    :param value:          Default integer value
+    :type  bits:           int
+    :param bits:           Width of integer numbers, in bits. Default: 128
+    :type  max_num:        int
+    :param max_num:        Maximum number to iterate up to. Takes precedence over bits
+    :type  full_range:     bool
+    :param full_range:     (Optional, def=False) If enabled the field mutates through *all* possible values.
+    :type  fuzzable:       bool
+    :param fuzzable:       (Optional, def=True) Enable/disable fuzzing of this primitive
+    :type  name:           str
+    :param name:           (Optional, def=None) Specifying a name gives you direct access to a primitive
+    """
+
+    integers = primitives.Integers(value, bits, max_num, signed, fuzzable, name)
+    blocks.CURRENT.push(integers)
 
 
 # ALIASES

--- a/boofuzz/primitives/__init__.py
+++ b/boofuzz/primitives/__init__.py
@@ -12,6 +12,7 @@ from .random_data import RandomData
 from .static import Static
 from .string import String
 from .word import Word
+from .integers import Integers
 
 __all__ = [
     "BasePrimitive",
@@ -21,6 +22,7 @@ __all__ = [
     "DWord",
     "FromFile",
     "Group",
+    "Integers",
     "Mirror",
     "QWord",
     "RandomData",

--- a/boofuzz/primitives/integers.py
+++ b/boofuzz/primitives/integers.py
@@ -24,4 +24,4 @@ class Integers(BitField):
         self.bits = bits
         self.max_num = max_num
 
-        super(Integers, self).__init__(value, width=bits, signed=signed, name=None, output_format="ascii")
+        super(Integers, self).__init__(value, width=bits, signed=signed, name=name, output_format="ascii")

--- a/boofuzz/primitives/integers.py
+++ b/boofuzz/primitives/integers.py
@@ -1,0 +1,30 @@
+import six
+import struct
+
+from boofuzz.primitives.bit_field import BitField
+
+
+class Integers(BitField):
+    def __init__(self, value, bits=128, max_num=None, signed=True, name=None, *args, **kwargs):
+        """
+        The Integers primitive represents integers of arbitrary value.
+
+        @type  value:          int
+        @param value:          Default integer value
+        @type  bits:           int
+        @param bits:           Width of integer numbers, in bits. Default: 128. Ignored if max_num is set
+        @type  max_num:        int
+        @param max_num:        Maximum number to iterate up to. Takes precedence over bits
+        @type  full_range:     bool
+        @param full_range:     (Optional, def=False) If enabled the field mutates through *all* possible values
+        @type  fuzzable:       bool
+        @param fuzzable:       (Optional, def=True) Enable/disable fuzzing of this primitive
+        @type  name:           str
+        @param name:           (Optional, def=None) Specifying a name gives you direct access to a primitive
+        """
+        self.output_format = "ascii"
+        self.signed = signed
+        self.bits = bits
+        self.max_num = max_num
+
+        super(Integers, self).__init__(value, width=bits, signed=signed, name=None, output_format="ascii")

--- a/boofuzz/primitives/integers.py
+++ b/boofuzz/primitives/integers.py
@@ -1,6 +1,3 @@
-import six
-import struct
-
 from boofuzz.primitives.bit_field import BitField
 
 


### PR DESCRIPTION
The idea behind this module is to make it simple to get integers in their decimal representation.

To test, execute this script:
```
from boofuzz import *

session = Session( target=Target( connection=SocketConnection( host="127.0.0.1", port=12345, proto='tcp', server=True ),),)
s_initialize("A")
s_integers(0)
session.connect(session.root, s_get("A"))
session.fuzz()
```

and then run  `nc 127.0.0.1 12345` in another system console.