### PR TITLE
Remove sudo from install instructions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,7 @@ Fixes
 - Fixed process monitor handling of backslashes in Windows start commands
 - Fixed and documented `boo open`
 - Fixed receive function in `fuzz_logger_curses`
+- Installing boofuzz with `sudo` is no longer recommended, use the `--user` option of pip instead
 
 v0.1.5
 ------

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -8,9 +8,6 @@ Boofuzz requires Python. Recommended installation requires ``pip``.
 
 Ubuntu: ``sudo apt-get install python-pip``
 
-Windows: See this `help site`_ but make sure to get Python 2.x instead
-of 3.x (pip is included).
-
 Install
 -------
 ::
@@ -20,11 +17,11 @@ Install
 From Source
 -----------
 
-1. Download source code: `https://github.com/jtpereyda/boofuzz`_
+1. Download source code: https://github.com/jtpereyda/boofuzz
 2. Install. Run ``pip`` from within the boofuzz directory:
+   ::
 
-   -  Ubuntu: ``sudo pip install .``
-   -  Windows: ``pip install .``
+       pip install .
 
 Tips:
 
@@ -33,23 +30,19 @@ Tips:
 
    ::
 
-       `sudo pip install -e .`
+       pip install -e .
 
 -  To install developer tools (unit test dependencies, test runners, etc.) as well:
 
    ::
 
-       `sudo pip install -e .[dev]`
+       pip install -e .[dev]
 
 -  If you’re behind a proxy:
 
    ::
 
-       `set HTTPS_PROXY=http://your.proxy.com:port`
-
-   -  On Linux, also use ``sudo``\ ’s ``-E`` option:
-
-      ``sudo -E pip install -e .``
+       set HTTPS_PROXY=http://your.proxy.com:port
 
 Extras
 ------

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -12,7 +12,7 @@ Install
 -------
 ::
 
-    pip install boofuzz
+    pip install boofuzz --user
 
 From Source
 -----------
@@ -21,7 +21,7 @@ From Source
 2. Install. Run ``pip`` from within the boofuzz directory:
    ::
 
-       pip install .
+       pip install . --user
 
 Tips:
 
@@ -30,13 +30,13 @@ Tips:
 
    ::
 
-       pip install -e .
+       pip install -e . --user
 
 -  To install developer tools (unit test dependencies, test runners, etc.) as well:
 
    ::
 
-       pip install -e .[dev]
+       pip install -e .[dev] --user
 
 -  If you’re behind a proxy:
 

--- a/README.rst
+++ b/README.rst
@@ -61,7 +61,7 @@ Installation
 ------------
 ::
 
-    pip install boofuzz
+    pip install boofuzz --user
 
 
 Boofuzz installs as a Python library used to build fuzzer scripts. See

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -57,7 +57,7 @@ Installation
 ------------
 ::
 
-    pip install boofuzz
+    pip install boofuzz --user
 
 
 Boofuzz installs as a Python library used to build fuzzer scripts. See


### PR DESCRIPTION
Adressing #326 + some syntax errors.

Tested in a virtualenv under Ubuntu 19.04 where installing without `sudo` worked fine in every case.