### PR TITLE
Enable "open_connection_keep_trying" for servers as well

### DIFF
--- a/boofuzz/socket_connection.py
+++ b/boofuzz/socket_connection.py
@@ -167,7 +167,8 @@ class SocketConnection(itarget_connection.ITargetConnection):
                     self._serverSock.listen(1)
                     self._sock, addr = self._serverSock.accept()
                 except socket.error as e:
-                    # When connection timeout expires, tear down the server socket so we can re-open it again after restarting target
+                    # When connection timeout expires, tear down the server socket so we can re-open it again after
+                    # restarting the target.
                     self._serverSock.shutdown(socket.SHUT_RDWR)
                     self._serverSock.close()
                     if e.errno in [errno.EAGAIN]:

--- a/boofuzz/socket_connection.py
+++ b/boofuzz/socket_connection.py
@@ -175,8 +175,8 @@ class SocketConnection(itarget_connection.ITargetConnection):
                     self._sock, addr = self._serverSock.accept()
                 except socket.error as e:
                     # When connection timeout expires, tear down the server socket so we can re-open it again after
-                    # restarting the target. Can't just call self.close() because self._sock isn't as expected for it.
-                    self._serverSock.close()
+                    # restarting the target.
+                    self.close()
                     if e.errno in [errno.EAGAIN]:
                         raise exception.BoofuzzTargetConnectionFailedError(str(e))
                     else:

--- a/boofuzz/socket_connection.py
+++ b/boofuzz/socket_connection.py
@@ -168,8 +168,7 @@ class SocketConnection(itarget_connection.ITargetConnection):
                     self._sock, addr = self._serverSock.accept()
                 except socket.error as e:
                     # When connection timeout expires, tear down the server socket so we can re-open it again after
-                    # restarting the target.
-                    self._serverSock.shutdown(socket.SHUT_RDWR)
+                    # restarting the target. Can't call self.close() because we don't have a valid self._sock.
                     self._serverSock.close()
                     if e.errno in [errno.EAGAIN]:
                         raise exception.BoofuzzTargetConnectionFailedError(str(e))


### PR DESCRIPTION
I had an issue where I am fuzzing as a server, waiting for the target client to connect to the server. Sometimes the client hits a retry limit and gives up so the server is left waiting indefinitely for a connection to use for fuzzing.

I used recv_timeout and send_timeout on the SocketConnection used by the Target, which lets the server give up on that connection attempt. However, this raises an uncaught EAGAIN exception, killing the fuzzing session. Plus, I could not find a satisfactory built-in method to restart the target _only when needed_ for this connection attempt being abandoned.

So I found the open_connection_keep_trying feature that was added for clients (#268 ) and modified the connection code when running as a server to tie into the same feature. Now I can define a function to restart my target which gets called when the server times out waiting for a client to connect.