### PR TITLE
added error handling to byte decoding in csv logger

### DIFF
--- a/boofuzz/fuzz_logger_csv.py
+++ b/boofuzz/fuzz_logger_csv.py
@@ -53,10 +53,10 @@ class FuzzLoggerCsv(ifuzz_logger_backend.IFuzzLoggerBackend):
         self._print_log_msg(["error", "", "", description])
 
     def log_recv(self, data):
-        self._print_log_msg(["recv", len(data), self._format_raw_bytes(data), data.decode(errors='replace')])
+        self._print_log_msg(["recv", len(data), self._format_raw_bytes(data), data.decode(errors="replace")])
 
     def log_send(self, data):
-        self._print_log_msg(["send", len(data), self._format_raw_bytes(data), data.decode(errors='replace')])
+        self._print_log_msg(["send", len(data), self._format_raw_bytes(data), data.decode(errors="replace")])
 
     def log_info(self, description):
         self._print_log_msg(["info", "", "", description])

--- a/boofuzz/fuzz_logger_csv.py
+++ b/boofuzz/fuzz_logger_csv.py
@@ -53,10 +53,10 @@ class FuzzLoggerCsv(ifuzz_logger_backend.IFuzzLoggerBackend):
         self._print_log_msg(["error", "", "", description])
 
     def log_recv(self, data):
-        self._print_log_msg(["recv", len(data), self._format_raw_bytes(data), data.decode()])
+        self._print_log_msg(["recv", len(data), self._format_raw_bytes(data), data.decode(errors='replace')])
 
     def log_send(self, data):
-        self._print_log_msg(["send", len(data), self._format_raw_bytes(data), data.decode()])
+        self._print_log_msg(["send", len(data), self._format_raw_bytes(data), data.decode(errors='replace')])
 
     def log_info(self, description):
         self._print_log_msg(["info", "", "", description])


### PR DESCRIPTION
This fixes issues arising from *non-decodable* bytes in the fuzzing payload. While the `_format_raw_bytes` function can be injected from outside, it does not seem that the second decode can be skipped.
A regression test for this would be simple if wanted. I'd just have to first acquaint myself with the test syntax and tooling.