### PR TITLE
Update documentation links and add sphinx linkcheck to tox

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,15 +4,15 @@ boofuzz: Network Protocol Fuzzing for Humans
 .. image:: https://travis-ci.org/jtpereyda/boofuzz.svg?branch=master
     :target: https://travis-ci.org/jtpereyda/boofuzz
 .. image:: https://readthedocs.org/projects/boofuzz/badge/?version=latest
-    :target: http://boofuzz.readthedocs.io/en/latest/?badge=latest
+    :target: https://boofuzz.readthedocs.io/en/latest/?badge=latest
     :alt: Documentation Status
 .. image:: https://img.shields.io/pypi/v/boofuzz.svg
-    :target: https://pypi.python.org/pypi/boofuzz
+    :target: https://pypi.org/project/boofuzz/
 .. image:: https://badges.gitter.im/jtpereyda/boofuzz.svg
     :alt: Join the chat at https://gitter.im/jtpereyda/boofuzz
-    :target: https://gitter.im/jtpereyda/boofuzz?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
+    :target: https://gitter.im/jtpereyda/boofuzz
 .. image:: https://img.shields.io/badge/code%20style-black-000000.svg
-    :target: https://github.com/python/black
+    :target: https://github.com/psf/black
 
 Boofuzz is a fork of and the successor to the venerable `Sulley`_ fuzzing
 framework. Besides numerous bug fixes, boofuzz aims for extensibility.
@@ -124,12 +124,12 @@ here on GitHub.
 
 For other questions, check out boofuzz on `gitter`_ or `Google Groups`_.
 
-For updates, follow `@fuzztheplanet`_ on Twitter.
+For updates, follow `@b00fuzz`_ on Twitter.
 
 .. _Sulley: https://github.com/OpenRCE/sulley
 .. _Google Groups: https://groups.google.com/d/forum/boofuzz
 .. _gitter: https://gitter.im/jtpereyda/boofuzz
-.. _@fuzztheplanet: https://twitter.com/fuzztheplanet
+.. _@b00fuzz: https://twitter.com/b00fuzz
 .. _boofuzz-ftp: https://github.com/jtpereyda/boofuzz-ftp
 .. _boofuzz-http: https://github.com/jtpereyda/boofuzz-http
 

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,9 @@ commands =
     unix: sudo {envpython} -m pytest
     {envpython} -m check_manifest
     windows: .\docs\make.bat dummy
+    windows: .\docs\make.bat linkcheck
     unix: make -C ./docs dummy
+    unix: make -C ./docs linkcheck
 commands_post =
     windows: - cmd /c for %d in ('boofuzz-results' '.\docs\_build') do rmdir '%~d' /s /q
     unix: sudo rm -rf ./boofuzz-results/ ./docs/_build/


### PR DESCRIPTION
Some links in the documentation were outdated, so I updated them and added a link checker to tox.
This should give us a warning in case of broken links in the future.

I shorted the link to the gitter page by the stats/reference arguments. If those were included for a reason, I'll add them back.