### PR TITLE
Fix csv logger data decoding

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,7 @@ Fixes
 - Installing boofuzz with `sudo` is no longer recommended, use the `--user` option of pip instead
 - Fixed setting socket timeout options on Windows
 - If all sockets are exhausted, repeatedly try fuzzing for 4 minutes before failing
+- Fixed CSV logger send and receive data decoding
 
 v0.1.5
 ------

--- a/boofuzz/fuzz_logger_csv.py
+++ b/boofuzz/fuzz_logger_csv.py
@@ -53,10 +53,10 @@ class FuzzLoggerCsv(ifuzz_logger_backend.IFuzzLoggerBackend):
         self._print_log_msg(["error", "", "", description])
 
     def log_recv(self, data):
-        self._print_log_msg(["recv", len(data), self._format_raw_bytes(data), data.decode()])
+        self._print_log_msg(["recv", len(data), self._format_raw_bytes(data), repr(data)])
 
     def log_send(self, data):
-        self._print_log_msg(["send", len(data), self._format_raw_bytes(data), data.decode()])
+        self._print_log_msg(["send", len(data), self._format_raw_bytes(data), repr(data)])
 
     def log_info(self, description):
         self._print_log_msg(["info", "", "", description])

--- a/unit_tests/test_fuzz_logger_csv.py
+++ b/unit_tests/test_fuzz_logger_csv.py
@@ -179,7 +179,7 @@ class TestFuzzLoggerCsv(unittest.TestCase):
                 + ","
                 + fuzz_logger_csv.DEFAULT_HEX_TO_STR(self.some_recv_data)
                 + ","
-                + self.some_recv_data.decode()
+                + repr(self.some_recv_data)
                 + "\r\n"
             ),
         )
@@ -215,7 +215,7 @@ class TestFuzzLoggerCsv(unittest.TestCase):
                 + ","
                 + fuzz_logger_csv.DEFAULT_HEX_TO_STR(self.some_send_data)
                 + ","
-                + self.some_send_data.decode()
+                + repr(self.some_send_data)
                 + "\r\n"
             ),
         )
@@ -399,7 +399,8 @@ class TestFuzzLoggerCsv(unittest.TestCase):
         six.assertRegex(
             self,
             self.virtual_file.readline(),
-            LOGGER_PREAMBLE + re.escape("recv,0," + fuzz_logger_csv.DEFAULT_HEX_TO_STR(bytes(b"")) + ",\r\n"),
+            LOGGER_PREAMBLE
+            + re.escape("recv,0," + fuzz_logger_csv.DEFAULT_HEX_TO_STR(bytes(b"")) + "," + repr(b"") + "\r\n"),
         )
 
     def test_log_send_empty(self):
@@ -425,7 +426,8 @@ class TestFuzzLoggerCsv(unittest.TestCase):
         six.assertRegex(
             self,
             self.virtual_file.readline(),
-            LOGGER_PREAMBLE + re.escape("send,0," + fuzz_logger_csv.DEFAULT_HEX_TO_STR(bytes(b"")) + ",\r\n"),
+            LOGGER_PREAMBLE
+            + re.escape("send,0," + fuzz_logger_csv.DEFAULT_HEX_TO_STR(bytes(b"")) + "," + repr(b"") + "\r\n"),
         )
 
     def test_log_info_empty(self):
@@ -545,7 +547,7 @@ class TestFuzzLoggerCsv(unittest.TestCase):
                 + ","
                 + fuzz_logger_csv.DEFAULT_HEX_TO_STR(self.some_recv_data)
                 + ","
-                + self.some_recv_data.decode()
+                + repr(self.some_recv_data)
                 + "\r\n"
             ),
         )
@@ -559,7 +561,7 @@ class TestFuzzLoggerCsv(unittest.TestCase):
                 + ","
                 + fuzz_logger_csv.DEFAULT_HEX_TO_STR(self.some_send_data)
                 + ","
-                + self.some_send_data.decode()
+                + repr(self.some_send_data)
                 + "\r\n"
             ),
         )
@@ -597,7 +599,7 @@ class TestFuzzLoggerCsv(unittest.TestCase):
 
         # Given
         def hex_to_str(hex_data):
-            return hex_data.decode()
+            return repr(hex_data)
 
         self.logger = fuzz_logger_csv.FuzzLoggerCsv(file_handle=self.virtual_file, bytes_to_str=hex_to_str)
         # When
@@ -623,7 +625,7 @@ class TestFuzzLoggerCsv(unittest.TestCase):
                 + ","
                 + hex_to_str(self.some_recv_data)
                 + ","
-                + self.some_recv_data.decode()
+                + repr(self.some_recv_data)
                 + "\r\n"
             ),
         )


### PR DESCRIPTION
Fix for an error when calling `decode()` on non ASCII bytes data while logging sent/received data with the csv logger class.

This fix was split off from #334 to speed up the merging process. Thanks to @JsHuang

A review would be much appreciated @jtpereyda @JsHuang @dorpvom @starek4 