### PR TITLE
Fix s_from_file decoding in Python 2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,7 @@ Fixes
 - Fixed setting socket timeout options on Windows
 - If all sockets are exhausted, repeatedly try fuzzing for 4 minutes before failing
 - Fixed CSV logger send and receive data decoding
+- Fixed `s_from_file` decoding in Python 2 (the encoding parameter is now depreciated)
 
 v0.1.5
 ------

--- a/boofuzz/__init__.py
+++ b/boofuzz/__init__.py
@@ -637,7 +637,7 @@ def s_from_file(value, encoding="ascii", fuzzable=True, max_len=0, name=None, fi
     :type  value:    str
     :param value:    Default string value
     :type  encoding: str
-    :param encoding: (Optonal, def="ascii") String encoding, ex: utf_16_le for Microsoft Unicode.
+    :param encoding: (DEPRECIATED, def="ascii") String encoding, ex: utf_16_le for Microsoft Unicode.
     :type  fuzzable: bool
     :param fuzzable: (Optional, def=True) Enable/disable fuzzing of this primitive
     :type  max_len:  int
@@ -648,7 +648,7 @@ def s_from_file(value, encoding="ascii", fuzzable=True, max_len=0, name=None, fi
     :param filename: (Mandatory) Specify filename where to read fuzz list
     """
 
-    s = primitives.FromFile(value, encoding, fuzzable, max_len, name, filename)
+    s = primitives.FromFile(value, fuzzable, max_len, name, filename)
     blocks.CURRENT.push(s)
 
 

--- a/boofuzz/primitives/from_file.py
+++ b/boofuzz/primitives/from_file.py
@@ -32,7 +32,7 @@ class FromFile(BasePrimitive):
         list_of_files = glob.glob(self._filename)
         for fname in list_of_files:
             with open(fname, "rb") as _file_handle:
-                self._fuzz_library.extend(_file_handle.readlines())
+                self._fuzz_library.extend(list(filter(None, _file_handle.read().splitlines())))
 
         # TODO: Make this more clear
         if max_len > 0:

--- a/boofuzz/primitives/from_file.py
+++ b/boofuzz/primitives/from_file.py
@@ -5,15 +5,13 @@ from .base_primitive import BasePrimitive
 
 
 class FromFile(BasePrimitive):
-    def __init__(self, value, encoding="ascii", fuzzable=True, max_len=0, name=None, filename=None):
+    def __init__(self, value, fuzzable=True, max_len=0, name=None, filename=None):
         """
         Cycles through a list of "bad" values from a file(s). Takes filename and open the file(s) to read
         the values to use in fuzzing process. filename may contain glob characters.
 
         @type  value:    str
         @param value:    Default string value
-        @type  encoding: str
-        @param encoding: (Optional, def="ascii") String encoding, ex: utf_16_le for Microsoft Unicode.
         @type  fuzzable: bool
         @param fuzzable: (Optional, def=True) Enable/disable fuzzing of this primitive
         @type  max_len:  int
@@ -27,14 +25,13 @@ class FromFile(BasePrimitive):
         super(FromFile, self).__init__()
 
         self._value = self._original_value = value
-        self.encoding = encoding
         self._fuzzable = fuzzable
         self._name = name
         self._filename = filename
         self._fuzz_library = []
         list_of_files = glob.glob(self._filename)
         for fname in list_of_files:
-            with open(fname, "r") as _file_handle:
+            with open(fname, "rb") as _file_handle:
                 self._fuzz_library.extend(_file_handle.readlines())
 
         # TODO: Make this more clear


### PR DESCRIPTION
Proposed fix for #351 

The problem here is, that file.read() returns a unicode type instead of string. This causes issues when logging the data at a later point.

Fixes:
- Switched to byte wise reading of files for s_from_file to bypass decoding.
- Marked the `encoding` parameter of this primitive as depreciated. It wasn't even implemented before.

TODO:

- [X] Remove tailing newline operator \n from data when reading the file