### PR TITLE
Update documentation of s_checksum

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,6 +28,7 @@ Fixes
 - Fixed CSV logger send and receive data decoding
 - Handle SSL-related exception. Added `ignore_connection_ssl_errors` session attribute that can
   be set to True to ignore SSL-related error on a test case.
+- Updated documentation of `s_checksum`. It is possible to use a custom algorithm with this block.
 
 v0.1.5
 ------

--- a/boofuzz/__init__.py
+++ b/boofuzz/__init__.py
@@ -130,6 +130,7 @@ __all__ = [
 
 __version__ = "0.1.5"
 
+
 # REQUEST MANAGEMENT
 def s_get(name=None):
     """
@@ -319,13 +320,15 @@ def s_checksum(
     currently open blocks.
 
     :type  block_name: str
-    :param block_name: Name of block to apply sizer to
+    :param block_name: Name of block for checksum calculations
 
-    :type  algorithm:  str
+    :type  algorithm:  str, function
     :param algorithm:  (Optional, def=crc32) Checksum algorithm to use. (crc32, adler32, md5, sha1, ipv4, udp)
+                       Pass a function to use a custom algorithm. This function has to take and return byte-type data.
 
     :type  length:     int
-    :param length:     (Optional, def=0) NOT IMPLEMENTED. Length of checksum, specify 0 to auto-calculate
+    :param length:     (Optional, def=0) Length of checksum, auto-calculated by default. Must be specified manually when
+                       using a custom algorithm.
 
     :type  endian:     Character
     :param endian:     (Optional, def=LITTLE_ENDIAN) Endianness of the bit field (LITTLE_ENDIAN: <, BIG_ENDIAN: >)
@@ -370,7 +373,7 @@ def s_repeat(block_name, min_reps=0, max_reps=None, step=1, variable=None, fuzza
     :see: Aliases: s_repeater()
 
     :type  block_name: str
-    :param block_name: Name of block to apply sizer to
+    :param block_name: Name of block to repeat
     :type  min_reps:   int
     :param min_reps:   (Optional, def=0) Minimum number of block repetitions
     :type  max_reps:   int

--- a/boofuzz/blocks/checksum.py
+++ b/boofuzz/blocks/checksum.py
@@ -35,7 +35,8 @@ class Checksum(primitives.BasePrimitive):
     Args:
         block_name (str): Name of target block for checksum calculations.
         request (s_request): Request this block belongs to.
-        algorithm (Union[str, function], optional): Checksum algorithm to use. (crc32, adler32, md5, sha1, ipv4, udp)
+        algorithm (str, function, optional): Checksum algorithm to use. (crc32, adler32, md5, sha1, ipv4, udp)
+            Pass a function to use a custom algorithm. This function has to take and return byte-type data.
         length (int, optional): Length of checksum, auto-calculated by default.
             Must be specified manually when using custom algorithm.
         endian (str, optional): Endianness of the bit field (LITTLE_ENDIAN: <, BIG_ENDIAN: >).
@@ -121,9 +122,7 @@ class Checksum(primitives.BasePrimitive):
         return self._fuzzable and (self._mutant_index != 0) and not self._fuzz_complete
 
     def _get_dummy_value(self):
-        if self._length:
-            return self._length * "\x00"
-        return self.checksum_lengths[self._algorithm] * "\x00"
+        return self._length * "\x00"
 
     @_may_recurse
     def _render_block(self, block_name):
@@ -134,9 +133,9 @@ class Checksum(primitives.BasePrimitive):
         Calculate and return the checksum (in raw bytes) of data.
 
         :param data Data on which to calculate checksum.
-        :type data str
+        :type data bytes
 
-        :rtype:  str
+        :rtype:  bytes
         :return: Checksum.
         """
         if isinstance(self._algorithm, six.string_types):

--- a/boofuzz/blocks/repeat.py
+++ b/boofuzz/blocks/repeat.py
@@ -17,7 +17,7 @@ class Repeat(ifuzzable.IFuzzable):
         modifier MUST come after the block it is being applied to.
 
         @type  block_name: str
-        @param block_name: Name of block to apply sizer to
+        @param block_name: Name of block to repeat
         @type  request:    s_request
         @param request:    Request this block belongs to
         @type  min_reps:   int


### PR DESCRIPTION
Recently two PRs about new checksum algorithms were opened. There is a possibility to use a custom checksum algorithm with `s_checksum`, which is currently not visible in the online documentation.
Even though it's nice to have a larger variety of checksum algorithms implemented, my guess is that people don't know about this feature, hence opening PRs.

This PR correctly advertises this feature and fixes some other minor copy-paste mistakes in the documentation.

Every review is welcome.