### PR TITLE
Fix ssl-error handling

### DIFF
--- a/boofuzz/socket_connection.py
+++ b/boofuzz/socket_connection.py
@@ -241,6 +241,9 @@ class SocketConnection(itarget_connection.ITargetConnection):
                 raise exception.SullyRuntimeError("INVALID PROTOCOL SPECIFIED: %s" % self.proto)
         except socket.timeout:
             data = b""
+        except ssl.SSLError as e:
+            # If an SSL error is thrown the connection should be treated as lost
+            raise_(exception.BoofuzzSSLError(e.reason))
         except socket.error as e:
             if e.errno == errno.ECONNABORTED:
                 raise_(
@@ -254,9 +257,6 @@ class SocketConnection(itarget_connection.ITargetConnection):
                 data = b""
             else:
                 raise
-        except ssl.SSLError as e:
-            # If an SSL error is thrown the connection should be treated as lost
-            raise_(exception.BooFuzzSSLError(e.reason))
 
         return data
 
@@ -305,6 +305,9 @@ class SocketConnection(itarget_connection.ITargetConnection):
                 num_sent = self._sock.sendto(data, (self.host, self.ethernet_proto, 0, 0, self.l2_dst))
             else:
                 raise exception.SullyRuntimeError("INVALID PROTOCOL SPECIFIED: %s" % self.proto)
+        except ssl.SSLError as e:
+            # If an SSL error is thrown the connection should be treated as lost
+            raise_(exception.BoofuzzSSLError(e.reason))
         except socket.error as e:
             if e.errno == errno.ECONNABORTED:
                 raise_(
@@ -321,9 +324,6 @@ class SocketConnection(itarget_connection.ITargetConnection):
                 raise_(exception.BoofuzzTargetConnectionReset(), None, sys.exc_info()[2])
             else:
                 raise
-        except ssl.SSLError as e:
-            # If an SSL error is thrown the connection should be treated as lost
-            raise_(exception.BooFuzzSSLError(e.reason))
 
         return num_sent
 


### PR DESCRIPTION
- Fixing a typo in `exception.BooFuzzSSLError(e.reason)` which should be `exception.BoofuzzSSLError(e.reason)` instead.
- Resolve static analysis warning of PyCharm by catching ssl-errors before socket-errors. Before Python 3.3 SSLError used to be a subtype of socket.error. For versions prior to Python 3.3 we need to catch SSLError before socket.error, or it won't be caught correctly.
See #348 and https://docs.python.org/3/library/ssl.html#ssl.SSLError