### PR TITLE
Update docs link to RTD project root

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,15 +4,15 @@ boofuzz: Network Protocol Fuzzing for Humans
 .. image:: https://travis-ci.org/jtpereyda/boofuzz.svg?branch=master
     :target: https://travis-ci.org/jtpereyda/boofuzz
 .. image:: https://readthedocs.org/projects/boofuzz/badge/?version=latest
-    :target: http://boofuzz.readthedocs.io/en/latest/?badge=latest
+    :target: https://boofuzz.readthedocs.io/
     :alt: Documentation Status
 .. image:: https://img.shields.io/pypi/v/boofuzz.svg
-    :target: https://pypi.python.org/pypi/boofuzz
+    :target: https://pypi.org/project/boofuzz/
 .. image:: https://badges.gitter.im/jtpereyda/boofuzz.svg
     :alt: Join the chat at https://gitter.im/jtpereyda/boofuzz
-    :target: https://gitter.im/jtpereyda/boofuzz?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge
+    :target: https://gitter.im/jtpereyda/boofuzz
 .. image:: https://img.shields.io/badge/code%20style-black-000000.svg
-    :target: https://github.com/python/black
+    :target: https://github.com/psf/black
 
 Boofuzz is a fork of and the successor to the venerable `Sulley`_ fuzzing
 framework. Besides numerous bug fixes, boofuzz aims for extensibility.
@@ -71,7 +71,7 @@ Boofuzz installs as a Python library used to build fuzzer scripts. See
 Documentation
 -------------
 
-Documentation is available at http://boofuzz.readthedocs.io/, including nifty quickstart guides.
+Documentation is available at https://boofuzz.readthedocs.io/, including nifty quickstart guides.
 
 Contributions
 -------------
@@ -97,6 +97,6 @@ For updates, follow `@b00fuzz`_ on Twitter.
 .. _Google Groups: https://groups.google.com/d/forum/boofuzz
 .. _gitter: https://gitter.im/jtpereyda/boofuzz
 .. _@b00fuzz: https://twitter.com/b00fuzz
-.. _documentation: http://boofuzz.readthedocs.io/
+.. _documentation: https://boofuzz.readthedocs.io/
 .. _INSTALL.rst: INSTALL.rst
 .. _CONTRIBUTING.rst: CONTRIBUTING.rst

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,7 @@ boofuzz: Network Protocol Fuzzing for Humans
 .. image:: https://travis-ci.org/jtpereyda/boofuzz.svg?branch=master
     :target: https://travis-ci.org/jtpereyda/boofuzz
 .. image:: https://readthedocs.org/projects/boofuzz/badge/?version=latest
-    :target: https://boofuzz.readthedocs.io/en/latest/?badge=latest
+    :target: https://boofuzz.readthedocs.io/
     :alt: Documentation Status
 .. image:: https://img.shields.io/pypi/v/boofuzz.svg
     :target: https://pypi.org/project/boofuzz/


### PR DESCRIPTION
In the current state, any changes to the documentation on the master branch will directly be published to RTD on the latest tag. This behaviour might raise confusion, when users who don't install from source read the docs, as the docs might not match with the installed code.

This can be resolved by creating a stable tag on RTD that always reflects the documentation at the point of the most recent release.
The changes in this PR update the links in the documentation files to point at the project root of the boofuzz RTD project. The default version there is stable, so that users will be redirected to the correct version (stable).
Fixes #365 

Changes to other links than the documentation were made to complete #346 consistently.