### PR TITLE
Use merge=union to reduce CHANGELOG conflicts

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+CHANGELOG.rst merge=union


### PR DESCRIPTION
Whenever two PRs change the same line of the changelog and one gets merged, the other one is stuck in a merge conflict.

Setting the merge strategy to [union](https://git-scm.com/docs/gitattributes#Documentation/gitattributes.txt-union) will fix this. The only downside is that the order of the lines might not be chronological, which shouldn't be a problem as we usually reorder the lines before a release anyways.

Sadly this will only affect local merges as GitHub still doesn't read the `.gitattributes` file. Strangely GitLab does support this.
https://github.com/isaacs/github/issues/487
https://github.com/olivierlacan/keep-a-changelog/issues/56