### PR TITLE
Add s_bytes to the documentation

### DIFF
--- a/boofuzz/__init__.py
+++ b/boofuzz/__init__.py
@@ -748,7 +748,7 @@ def s_byte(
 
 def s_bytes(value, size=None, padding=b"\x00", fuzzable=True, max_len=None, name=None):
     """
-    Push a bytes field onto the current block stack.
+    Push a bytes field of arbitrary length onto the current block stack.
 
     :type  value:        bytes
     :param value:        Default binary value

--- a/docs/user/static-protocol-definition.rst
+++ b/docs/user/static-protocol-definition.rst
@@ -43,6 +43,7 @@ Primitive Definition
 .. autofunction:: boofuzz.s_from_file
 .. autofunction:: boofuzz.s_bit_field
 .. autofunction:: boofuzz.s_byte
+.. autofunction:: boofuzz.s_bytes
 .. autofunction:: boofuzz.s_word
 .. autofunction:: boofuzz.s_dword
 .. autofunction:: boofuzz.s_qword


### PR DESCRIPTION
We forgot to include `s_bytes` in the documentation in #302.