### PR TITLE
Codecov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,7 +20,7 @@ jobs:
           - os: windows-latest
             python-version: 3.5
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v1
       with:
@@ -41,3 +41,7 @@ jobs:
       env:
         TOXENV: ${{ format('py{0}-{1}', steps.py_tox_version.outputs.replaced, runner.os) }}
       run: tox --skip-missing-interpreters false
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,5 +9,5 @@ recursive-include request_definitions *.html *.py
 recursive-include unit_tests *.feature *.py
 recursive-include utils *.py
 
-exclude .readthedocs.yml .travis.yml
+exclude .readthedocs.yml .travis.yml codecov.yml
 prune docs/_build

--- a/README.rst
+++ b/README.rst
@@ -13,6 +13,8 @@ boofuzz: Network Protocol Fuzzing for Humans
     :target: https://gitter.im/jtpereyda/boofuzz
 .. image:: https://img.shields.io/badge/code%20style-black-000000.svg
     :target: https://github.com/psf/black
+.. image:: https://codecov.io/gh/jtpereyda/boofuzz/branch/master/graph/badge.svg
+    :target: https://codecov.io/gh/jtpereyda/boofuzz
 
 Boofuzz is a fork of and the successor to the venerable `Sulley`_ fuzzing
 framework. Besides numerous bug fixes, boofuzz aims for extensibility.

--- a/README.rst
+++ b/README.rst
@@ -13,8 +13,6 @@ boofuzz: Network Protocol Fuzzing for Humans
     :target: https://gitter.im/jtpereyda/boofuzz
 .. image:: https://img.shields.io/badge/code%20style-black-000000.svg
     :target: https://github.com/psf/black
-.. image:: https://codecov.io/gh/jtpereyda/boofuzz/branch/master/graph/badge.svg
-    :target: https://codecov.io/gh/jtpereyda/boofuzz
 
 Boofuzz is a fork of and the successor to the venerable `Sulley`_ fuzzing
 framework. Besides numerous bug fixes, boofuzz aims for extensibility.

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+codecov:
+  notify:
+    after_n_builds: 8
+
+coverage:
+  range: "50...70"
+
+comment: false

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,11 @@
 codecov:
   notify:
     after_n_builds: 8
+  status:
+    project:
+      default:
+        informational: True
+    patch: off
 
 coverage:
   range: "50...70"

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,13 +1,13 @@
 codecov:
   notify:
     after_n_builds: 8
+
+coverage:
+  range: "50...70"
   status:
     project:
       default:
         informational: True
     patch: off
-
-coverage:
-  range: "50...70"
 
 comment: false

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,3 +20,6 @@ filterwarnings =
 [pytype]
 exclude =
     **/ida_fuzz_library_extender.py
+
+[coverage:run]
+source = ./

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ extra_requirements = {
         "mock",
         "pytest",
         "pytest-bdd",
+        "pytest-cov",
         "netifaces",
         "ipaddress",
         "sphinx",

--- a/tox.ini
+++ b/tox.ini
@@ -21,9 +21,9 @@ commands_pre =
     # Code-Style check. exit-zero treats all errors as warnings.
     flake8 . --count --exit-zero --statistics
 commands =
-    Windows: {envpython} -m pytest
-    Linux: sudo {envpython} -m pytest
-    macOS: sudo {envpython} -m pytest
+    Windows: {envpython} -m pytest --cov --cov-report=xml
+    Linux: sudo {envpython} -m pytest --cov --cov-report=xml
+    macOS: sudo {envpython} -m pytest --cov --cov-report=xml
     {envpython} -m check_manifest
     Windows: .\docs\make.bat dummy
     Windows: .\docs\make.bat linkcheck


### PR DESCRIPTION
I felt like it was worth a try proposing codecov.

I tried to keep the impact of this as low as possible, so there won't be any annoying comments on PRs, just two new checks indicating the coverage diff of the PR.
One check is for the whole project, the other for the patch. I wasn't quite sure about what the patch check is good for, but it's the default setting so I left it in for now. We can always disable it later if it's not needed.

If those checks fail too often, we can also adjust some parameters or make tests always succeed so that they only indicate the coverage.

[Example PR](https://github.com/SR4ven/boofuzz/pull/3)
[PR on Codecov](https://codecov.io/gh/SR4ven/boofuzz/pull/3)

TODO (if we want this feature):

- [ ] Activate Codecov on the project (already done? https://codecov.io/gh/jtpereyda/boofuzz)
- [ ] Activate the [app](https://github.com/marketplace/codecov) (Open Source version)
- [ ] Set `CODECOV_TOKEN` secret on GitHub from https://codecov.io/gh/jtpereyda/boofuzz/settings