### PR TITLE
Rework tox

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,3 +45,16 @@ jobs:
       uses: codecov/codecov-action@v1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+  docs:
+    name: Build docs
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.x
+      uses: actions/setup-python@v1
+      with:
+        python-version: '3.x'
+    - name: Install pip and tox
+      run: python -m pip install --upgrade pip tox
+    - name: Run tox
+      run: tox --skip-missing-interpreters false -e docs

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -20,17 +20,29 @@ Pull Request Checklist
 
 1. Install python version 2.7.9+ **and** 3.6+
 
-2. Verify tests pass: ::
+2. Verify tests pass:
 
-      tox
+    .. code-block::
 
-   If the tests pass, check the output for new flake8 warnings that indicate PEP8 violations.
+        tox
 
-3. Format the code to meet our code style requirements (needs python 3.6+): ::
+    .. note::
+        (Re-)creating a tox environment on Linux requires root rights because some of your unit tests work with raw
+        sockets. tox will check if ``cap_net_admin`` and ``cap_net_raw+eip`` are set on the tox environment python
+        interpreter and if not, will do so.
 
-      black .
+        Once the capabilities have been set, running tox won't need extended permissions.
 
-   Use ``# fmt: off`` and ``# fmt: on`` around a block to locally disable formatting
+    .. attention::
+        If the tests pass, check the output for new flake8 warnings that indicate PEP8 violations.
+
+3. Format the code to meet our code style requirements (needs python 3.6+):
+
+    .. code-block::
+
+        black .
+
+    Use ``# fmt: off`` and ``# fmt: on`` around a block to disable formatting locally.
 
 4. If you have PyCharm, use it to see if your changes introduce any new static analysis warnings.
 
@@ -63,9 +75,9 @@ Prep
 
 2. Increment version number from last release according to PEP 0440 and roughly according to the Semantic Versioning guidelines.
 
-   1. In ``boofuzz/__init__.py``.
+    1. In ``boofuzz/__init__.py``.
 
-   2. In ``docs/conf.py``.
+    2. In ``docs/conf.py``.
 
 3. Modify CHANGELOG file for publication if needed.
 

--- a/boofuzz/__init__.py
+++ b/boofuzz/__init__.py
@@ -55,7 +55,8 @@ from .sessions import open_test_run, Session, Target
 if sys.platform == "win32" and sys.version_info >= (3, 8):
     import asyncio
 
-    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+    # noinspection PyUnresolvedReferences
+    asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())  # pytype: disable=module-attr
 
 __all__ = [
     "BasePrimitive",

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -2,7 +2,7 @@
 #
 
 # You can set these variables from the command line.
-SPHINXOPTS    = -TW # -nW optional for more harsh checking
+SPHINXOPTS    = -TW # apply changes to tox.ini accordingly
 SPHINXBUILD   = sphinx-build
 SPHINXPROJ    = boofuzz
 SOURCEDIR     = .

--- a/setup.py
+++ b/setup.py
@@ -33,22 +33,11 @@ def get_long_description():
 
 
 extra_requirements = {
-    "dev": [
-        "tox",
-        "flake8",
-        "check-manifest",
-        "mock",
-        "pytest",
-        "pytest-bdd",
-        "pytest-cov",
-        "netifaces",
-        "ipaddress",
-        "sphinx",
-        "sphinx_rtd_theme",
-        "pygments>=2.4.0",
-    ],
+    "dev": ["tox", "flake8", "check-manifest", "mock", "pytest", "pytest-bdd", "pytest-cov", "netifaces", "ipaddress"],
     "docs": ["sphinx", "sphinx_rtd_theme", "pygments>=2.4.0"],
 }
+extra_requirements["dev"] += extra_requirements["docs"]
+
 if sys.version_info >= (3, 6):
     extra_requirements["dev"] += ["black"]
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,36 +1,40 @@
 [tox]
 skip_missing_interpreters = True
-envlist = py{27,35,36,37,38}-{Linux,Windows,macOS}
+envlist = py{27,35,36,37,38}-{Linux,Windows,macOS}, docs, lint
 
 [testenv]
-whitelist_externals =
-    sudo
-    make
-    cmd
 platform =
     Windows: win32
     Linux: linux
     macOS: darwin
+whitelist_externals = bash
 extras = dev
-install_command =
-    {envpython} -m pip install {opts} {packages}
-commands_pre =
-    {envpython} -m pip check
-    # Stop the test if there are Python syntax errors or undefined names.
+commands =
+    pip check
+    Linux: bash -ec "if ! getcap $(realpath {envpython}) | grep -q cap_net_admin,cap_net_raw+eip; then sudo setcap cap_net_admin,cap_net_raw+eip $(realpath {envpython}); fi"
+    pytest --cov --cov-report=xml
+    check-manifest
+commands_post =
+    - python -c "import shutil; shutil.rmtree('./boofuzz-results/')"
+
+[testenv:docs]
+basepython = python3
+extras = docs
+commands =
+    sphinx-build -TW -b dummy ./docs ./docs/_build
+    sphinx-build -TW -b linkcheck ./docs ./docs/_build
+commands_post =
+    - python -c "import shutil; shutil.rmtree('./docs/_build')"
+
+[testenv:lint]
+basepython = python3
+deps =
+    black
+    flake8
+commands =
+    # Fail if there are Python syntax errors or undefined names.
     flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+    black --check .
     # Code-Style check. exit-zero treats all errors as warnings.
     flake8 . --count --exit-zero --statistics
-commands =
-    Windows: {envpython} -m pytest --cov --cov-report=xml
-    Linux: sudo {envpython} -m pytest --cov --cov-report=xml
-    macOS: sudo {envpython} -m pytest --cov --cov-report=xml
-    {envpython} -m check_manifest
-    Windows: .\docs\make.bat dummy
-    Windows: .\docs\make.bat linkcheck
-    Linux: make -C ./docs dummy
-    Linux: make -C ./docs linkcheck
-    macOS: make -C ./docs dummy
-    macOS: make -C ./docs linkcheck
 commands_post =
-    Windows: - cmd /c for %d in ('boofuzz-results' '.\docs\_build') do rmdir '%~d' /s /q
-    Linux: sudo rm -rf ./boofuzz-results/ ./docs/_build/

--- a/tox.ini
+++ b/tox.ini
@@ -28,6 +28,7 @@ commands_post =
 
 [testenv:lint]
 basepython = python3
+skip_install = true
 deps =
     black
     flake8


### PR DESCRIPTION
Changes and benefits:
- Most commands in tox are now platform independent.
  Only exception is a one-line bash script on Linux, which sets `cap_net_admin` and `cap_net_raw+eip` on the tox python interpreter. This is done every time the tox env is (re-)created and requires root privileges. Subsequent runs won't need any special privileges.
  With this change we don't run pytest with sudo, so there won't be any cache/log/output/data files owned by root in your project folder. On top it's more secure, as we only grant the capabilities that are really required.
- Docs and lint checks now run in their own environment. The advantage is that we don't run these checks multiple times for every python and platform combination. It is also possible to run all tox envs in parallel using `tox -p auto`, which usually seem to work fine as long as all tests pass. As CI runs all envs in parallel, the less duplicated tests mean a reduced testing time.
  Outsourcing the docs env allows us to run it in a separate test on CI. So it is now easier to tell what went wrong without having to look at the logs.
  The lint check is no longer being run on CI. We have Stickler for that. On local dev environments executing `tox` runs black and flake8 linters. We can add pytest later.
  **Docs and Lint envs require a Python 3 interpreter now.** Else the tests will be skipped. I hope that nobody is developing boofuzz on Python 2 anymore :D
- Updated docs including some indentation fixes

Note:
Docs are not tested on travis anymore. I was planning on removing Travis when releasing v0.2.0. Are you ok with that @jtpereyda?