### PR TITLE
Fixed size of s_size block when output is ascii

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ Features
 
 Fixes
 ^^^^^
+- Fixed size of s_size block when output is ascii.
 - Fixed issue with tornado on Python 3.8 and Windows.
 - Fixed various potential type errors
 - Renamed `requests` folder to `request_definitions` because it shadowed the name of the `requests` python module

--- a/boofuzz/blocks/size.py
+++ b/boofuzz/blocks/size.py
@@ -220,10 +220,10 @@ class Size(IFuzzable):
         return "<%s %s>" % (self.__class__.__name__, self._name)
 
     def __len__(self):
-        if self.format == "binary":
-            return self.length
+        if self.format == "ascii":
+            return len(str(self._calculated_length()))
         else:
-            return len(str(len(self.request.names[self.block_name])))
+            return self.length
 
     def __bool__(self):
         """

--- a/boofuzz/blocks/size.py
+++ b/boofuzz/blocks/size.py
@@ -220,7 +220,10 @@ class Size(IFuzzable):
         return "<%s %s>" % (self.__class__.__name__, self._name)
 
     def __len__(self):
-        return self.length
+        if self.format == "binary":
+            return self.length
+        else:
+            return len(str(len(self.request.names[self.block_name])))
 
     def __bool__(self):
         """

--- a/boofuzz/blocks/size.py
+++ b/boofuzz/blocks/size.py
@@ -220,10 +220,7 @@ class Size(IFuzzable):
         return "<%s %s>" % (self.__class__.__name__, self._name)
 
     def __len__(self):
-        if self.format == "ascii":
-            return len(str(self._calculated_length()))
-        else:
-            return self.length
+        return len(self._render())
 
     def __bool__(self):
         """

--- a/boofuzz/primitives/bit_field.py
+++ b/boofuzz/primitives/bit_field.py
@@ -200,10 +200,7 @@ class BitField(BasePrimitive):
         return _rendered
 
     def __len__(self):
-        if self.format == "ascii":
-            return len(str(self._value))
-        else:
-            return self.width // 8
+        return len(self._render(self._value))
 
     def __bool__(self):
         """

--- a/boofuzz/primitives/bit_field.py
+++ b/boofuzz/primitives/bit_field.py
@@ -200,10 +200,10 @@ class BitField(BasePrimitive):
         return _rendered
 
     def __len__(self):
-        if self.format == "binary":
-            return self.width // 8
-        else:
+        if self.format == "ascii":
             return len(str(self._value))
+        else:
+            return self.width // 8
 
     def __bool__(self):
         """


### PR DESCRIPTION
If the output format of the s_size block is ascii, the __len__ function still returns 4 bytes. This commit takes into account the output format of the s_size block. Related to issue https://github.com/jtpereyda/boofuzz/issues/197 and pull request https://github.com/jtpereyda/boofuzz/pull/198