### PR TITLE
Disable Travis deploy stage

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,7 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Set up Python
       uses: actions/setup-python@v1
       with:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ language: python
 
 stages:
   - Test
-  - name: Deploy
-    if: (repo = jtpereyda/boofuzz) AND (fork = false) AND (tag IS present)
 
 jobs:
   include:
@@ -20,21 +18,6 @@ jobs:
       env: TOXENV=py37-Linux
     - python: 3.8
       env: TOXENV=py38-Linux
-
-    - stage: Deploy
-      install: true
-      script: skip
-      deploy:
-        provider: pypi
-        user: jtpereyda
-        password:
-          secure: GD7YRd2CmeSheZ4A85jVFp/aOLGD75M9WjK/Xc7d99OMBp19porIPbkYi+n+X/CQjl4lzUDVGNfvVZKXGVrY+QPxclfAHHIgb7Tc4nXFOWgaXrvw3LWsSfDreANacC105RGC3siGBkAWnMQgO/Q6N3LDHgy7A7XOa8t6sxedxeu1j0cJa0PmrQnvQy6+G+EpxxgrDphy5vwsIwEwRXRD6+4ekFKG81s7aWL1gvGcic/8JSnhc+jpNkbYrcf3edLT8NyMQlTnoplAYNrCMhPaFkNkstFlJvq2m84WlYUiqkTHOyPla07qaJaGPDt89LqqRISX2SNm2BjG5SqJ+6IkloS3Re83kzWL0kSXr9g4sqeCtsvvOhatEeRWEaOzCEE6pK5feLnagZKUL1ZXPu6ywl+yxxK5jcJE2PklvdMCL2KjdlF4CtMp3yg9a6X6VuPunzoXxVUn0cpj7xqenhMz2nDw1s7ZqFrCQ8ed8Pp+TfbmwZfnZ7GSdvywA4CaapOTLOfP4tWcV9GWiLOo0BjIFMac1tJCsHTjuQeRiUO47hpKGHf8+I7qltzlBJJNf/FGUoSqZjzy4o3zbuzfQHQbo2ueI8aS2C5VjjunbivBjp54eoIiu9rPbZl3uHmMWR74Stch0S2Amfj7d0ovZlaljkWWOf4R0tkuxDCtg+vnsy8=
-        distributions: sdist bdist_wheel
-        skip_cleanup: true
-        on:
-          tags: true
-          repo: jtpereyda/boofuzz
-          branch: master
 
 before_install: sudo sed -i -e 's/^Defaults\tsecure_path.*$//' /etc/sudoers
 install: pip install tox

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -66,7 +66,7 @@ On every pull request:
 
 Release Checklist
 -----------------
-Releases are deployed from Travis based on git tags.
+Releases are deployed from GitHub Actions when a new release is created on GitHub.
 
 Prep
 ++++
@@ -86,6 +86,6 @@ Prep
 Release
 +++++++
 
-1. Create release tag in Github.
+1. Create release on Github.
 
-2. Verify Travis deployment succeeds.
+2. Verify GitHub Actions deployment succeeds.

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
 boofuzz: Network Protocol Fuzzing for Humans
 ============================================
 
-.. image:: https://travis-ci.org/jtpereyda/boofuzz.svg?branch=master
-    :target: https://travis-ci.org/jtpereyda/boofuzz
+.. image:: https://github.com/jtpereyda/boofuzz/workflows/Test/badge.svg?branch=master
+    :target: https://github.com/jtpereyda/boofuzz/actions?query=workflow%3ATest+branch%3Amaster
 .. image:: https://readthedocs.org/projects/boofuzz/badge/?version=latest
     :target: https://boofuzz.readthedocs.io/
     :alt: Documentation Status

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -77,6 +77,12 @@ pygments_style = "stata-dark"
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False
 
+linkcheck_ignore = [
+    # Requires a more liberal 'Accept: ' HTTP request header:
+    # Ref: https://github.com/sphinx-doc/sphinx/issues/7247
+    r'https://github\.com/jtpereyda/boofuzz/workflows/[^/]+/badge\.svg',
+]
+
 
 # -- Options for HTML output ----------------------------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -80,7 +80,7 @@ todo_include_todos = False
 linkcheck_ignore = [
     # Requires a more liberal 'Accept: ' HTTP request header:
     # Ref: https://github.com/sphinx-doc/sphinx/issues/7247
-    r'https://github\.com/jtpereyda/boofuzz/workflows/[^/]+/badge\.svg',
+    r"https://github\.com/jtpereyda/boofuzz/workflows/[^/]+/badge\.svg",
 ]
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,8 +1,8 @@
 boofuzz: Network Protocol Fuzzing for Humans
 ============================================
 
-.. image:: https://travis-ci.org/jtpereyda/boofuzz.svg?branch=master
-    :target: https://travis-ci.org/jtpereyda/boofuzz
+.. image:: https://github.com/jtpereyda/boofuzz/workflows/Test/badge.svg?branch=master
+    :target: https://github.com/jtpereyda/boofuzz/actions?query=workflow%3ATest+branch%3Amaster
 .. image:: https://readthedocs.org/projects/boofuzz/badge/?version=latest
     :target: https://boofuzz.readthedocs.io/
     :alt: Documentation Status


### PR DESCRIPTION
Preparation for v0.2.0.

Whenever we push our next release, we don't want two CI services deploying at the same time.
We could completely remove Travis at this point, but as our new deploy Action hasn't been tested yet, I'd say keep Travis around until we're certain that everything works.

I switched out the status badge and updated the docs.
Currently, there is a problem with GitHub Action badge links and the Sphinx linkcheck, that's why I added a temporary ignore list until https://github.com/sphinx-doc/sphinx/issues/7247 is fixed.