### PR TITLE
Fix coverage scope

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,4 +23,4 @@ exclude =
     **/ida_fuzz_library_extender.py
 
 [coverage:run]
-source = ./
+source = ./boofuzz


### PR DESCRIPTION
I noticed that we currently generate a coverage report over the whole project folder.
That includes files out of the unit test scope like process_monitor.py, setup.py and the unit_tests folder itself. I figured that this doesn't make much sense, even though it boosts our coverage a little.

With this PR, only the boofuzz folder is used for coverage data.
That gives us much more accurate reports.