### PR TITLE
make s_string more intuitive

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -21,6 +21,7 @@ Fixes
 - Examples are up to date with current Boofuzz version
 - Modified timings on serial_connection unit tests to improve test reliability
 - Refactored old unit-tests
+- s_string(...) used `b"\x00"` as default padding instead of `"\x00"`. This broke on Python3 if you had set the `size` parameter and a string as `value`.
 
 v0.1.6
 ------

--- a/boofuzz/primitives/string.py
+++ b/boofuzz/primitives/string.py
@@ -11,7 +11,7 @@ class String(BasePrimitive):
     # store fuzz_library as a class variable to avoid copying the ~70MB structure across each instantiated primitive.
     _fuzz_library = []
 
-    def __init__(self, value, size=-1, padding=b"\x00", encoding="ascii", fuzzable=True, max_len=-1, name=None):
+    def __init__(self, value, size=-1, padding="\x00", encoding="ascii", fuzzable=True, max_len=-1, name=None):
         """
         Primitive that cycles through a library of "bad" strings. The class variable 'fuzz_library' contains a list of
         smart fuzz values global across all instances. The 'this_library' variable contains fuzz values specific to


### PR DESCRIPTION
Otherwise, this will break on Python3: `s_string("test", size=16)`.

