### PR TITLE
Change deprecation into future warnings

### DIFF
--- a/boofuzz/connections/socket_connection.py
+++ b/boofuzz/connections/socket_connection.py
@@ -81,7 +81,7 @@ def SocketConnection(
     warnings.warn(
         "SocketConnection is deprecated and will be removed in a future version of Boofuzz. "
         "Use the classes derived from BaseSocketConnection instead.",
-        DeprecationWarning,
+        FutureWarning,
     )
     if proto not in _PROTOCOLS:
         raise exception.SullyRuntimeError("INVALID PROTOCOL SPECIFIED: %s" % proto)

--- a/boofuzz/helpers.py
+++ b/boofuzz/helpers.py
@@ -123,7 +123,7 @@ def get_max_udp_size():
     warnings.warn(
         "get_max_udp_size() is deprecated and will be removed in a future version of boofuzz. "
         "Use UDPSocketConnection.max_payload() instead.",
-        DeprecationWarning,
+        FutureWarning,
     )
 
     return udp_socket_connection.UDPSocketConnection.max_payload()

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,7 +17,7 @@ ignore = .stickler.yml
 [tool:pytest]
 testpaths = unit_tests
 filterwarnings =
-    ignore:SocketConnection is deprecated:DeprecationWarning
+    ignore:SocketConnection is deprecated:FutureWarning
 
 [pytype]
 exclude =

--- a/unit_tests/test_socket_connection.py
+++ b/unit_tests/test_socket_connection.py
@@ -278,7 +278,6 @@ class TestSocketConnection(unittest.TestCase):
         t.daemon = True
         t.start()
 
-        # noinspection PyDeprecation
         uut = SocketConnection(host=socket.gethostname(), port=server.active_port, proto="tcp")
         uut.logger = logging.getLogger("SulleyUTLogger")
 
@@ -314,7 +313,6 @@ class TestSocketConnection(unittest.TestCase):
         t.daemon = True
         t.start()
 
-        # noinspection PyDeprecation
         uut = SocketConnection(host=socket.gethostname(), port=server.active_port, proto="tcp")
         uut.logger = logging.getLogger("SulleyUTLogger")
 
@@ -353,7 +351,6 @@ class TestSocketConnection(unittest.TestCase):
         t.daemon = True
         t.start()
 
-        # noinspection PyDeprecation
         uut = SocketConnection(
             host=socket.gethostname(), port=server.active_port, proto="udp", bind=(socket.gethostname(), 0)
         )
@@ -403,7 +400,6 @@ class TestSocketConnection(unittest.TestCase):
         t.daemon = True
         t.start()
 
-        # noinspection PyDeprecation
         uut = SocketConnection(
             host=broadcast_addr,
             port=server.active_port,
@@ -454,7 +450,6 @@ class TestSocketConnection(unittest.TestCase):
         server.data_to_send = "GKC"
         server.bind()
 
-        # noinspection PyDeprecation
         uut = SocketConnection(host="lo", proto="raw-l2", recv_timeout=0.1)
         uut.logger = logging.getLogger("SulleyUTLogger")
 
@@ -508,7 +503,6 @@ class TestSocketConnection(unittest.TestCase):
         server.data_to_send = "GKC"
         server.bind()
 
-        # noinspection PyDeprecation
         uut = SocketConnection(host="lo", proto="raw-l2", recv_timeout=0.1)
         uut.logger = logging.getLogger("SulleyUTLogger")
         data_to_send = b"1" * uut.max_send_size
@@ -555,7 +549,6 @@ class TestSocketConnection(unittest.TestCase):
         server.data_to_send = "GKC"
         server.bind()
 
-        # noinspection PyDeprecation
         uut = SocketConnection(host="lo", proto="raw-l2", recv_timeout=0.1)
         uut.logger = logging.getLogger("SulleyUTLogger")
         data_to_send = b"F" * (uut.max_send_size + 1)
@@ -606,7 +599,6 @@ class TestSocketConnection(unittest.TestCase):
         server.data_to_send = "GKC"
         server.bind()
 
-        # noinspection PyDeprecation
         uut = SocketConnection(host="lo", proto="raw-l3")
         uut.logger = logging.getLogger("SulleyUTLogger")
 
@@ -656,7 +648,6 @@ class TestSocketConnection(unittest.TestCase):
         server.data_to_send = "GKC"
         server.bind()
 
-        # noinspection PyDeprecation
         uut = SocketConnection(host="lo", proto="raw-l3")
         uut.logger = logging.getLogger("SulleyUTLogger")
         data_to_send = b"0" * uut.packet_size
@@ -703,7 +694,6 @@ class TestSocketConnection(unittest.TestCase):
         server.data_to_send = "GKC"
         server.bind()
 
-        # noinspection PyDeprecation
         uut = SocketConnection(host="lo", proto="raw-l3")
         uut.logger = logging.getLogger("SulleyUTLogger")
         data_to_send = b"D" * (uut.packet_size + 1)
@@ -733,7 +723,6 @@ class TestSocketConnection(unittest.TestCase):
         self.assertEqual(expected_server_receive, server.received)
         self.assertEqual(received, data_to_send[:-1])
 
-    # noinspection PyDeprecation
     def test_required_args_port(self):
         """
         Given: No preconditions.
@@ -751,7 +740,6 @@ class TestSocketConnection(unittest.TestCase):
         with self.assertRaises(Exception):
             SocketConnection(host="127.0.0.1", proto="ssl")
 
-    # noinspection PyDeprecation
     def test_optional_args_port(self):
         """
         Given: No preconditions.
@@ -763,7 +751,6 @@ class TestSocketConnection(unittest.TestCase):
         SocketConnection(host="127.0.0.1", proto="raw-l2")
         SocketConnection(host="127.0.0.1", proto="raw-l3")
 
-    # noinspection PyDeprecation
     def test_required_args_host(self):
         """
         Given: No preconditions.


### PR DESCRIPTION
Using `FutureWarning` instead of `DeprecationWarning` seems to make more sense as they aren't suppressed by default and are displayed to the user.