### PR TITLE
Network monitor Python 3 compatibility

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,7 @@ Fixes
 - Refactored old unit-tests
 - Removed deprecated session arguments `fuzz_data_logger`, `log_level`, `logfile`, `logfile_level` and `log()`.
 - Removed deprecated logger `FuzzLoggerFile`.
+- Fixed network monitor compatibility with Python 3.
 
 v0.1.6
 ------

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -177,6 +177,12 @@ The network monitor was Sulley’s primary tool for recording test data,
 and has been replaced with boofuzz’s logging mechanisms.
 However, some people still prefer the PCAP approach.
 
+.. note::
+    The network monitor requires Pcapy, which will not be automatically installed with boofuzz. You can manually
+    install it with ``pip install pcapy``.
+
+    If you run into errors, check out the requirements on the `project page <https://github.com/helpsystems/pcapy>`_.
+
 .. _help site: http://www.howtogeek.com/197947/how-to-install-python-on-windows/
 .. _releases page: https://github.com/jtpereyda/boofuzz/releases
 .. _`https://github.com/jtpereyda/boofuzz`: https://github.com/jtpereyda/boofuzz

--- a/network_monitor.py
+++ b/network_monitor.py
@@ -60,19 +60,19 @@ Network Device List:
     for index, pcapy_device in enumerate(ifs):
         # if we are on windows, try and resolve the device UUID into an IP address.
         if sys.platform.startswith("win"):
-            import _winreg  # pytype: disable=import-error
+            from six.moves import winreg  # pytype: disable=import-error
 
             try:
                 # extract the device UUID and open the TCP/IP parameters key for it.
                 pcapy_device = pcapy_device[pcapy_device.index("{") : pcapy_device.index("}") + 1]
                 subkey = r"SYSTEM\CurrentControlSet\Services\Tcpip\Parameters\Interfaces\%s" % pcapy_device
-                key = _winreg.OpenKey(_winreg.HKEY_LOCAL_MACHINE, subkey)
+                key = winreg.OpenKey(winreg.HKEY_LOCAL_MACHINE, subkey)
 
                 # if there is a DHCP address snag that, otherwise fall back to the IP address.
                 try:
-                    ip = _winreg.QueryValueEx(key, "DhcpIPAddress")[0]
+                    ip = winreg.QueryValueEx(key, "DhcpIPAddress")[0]
                 except Exception:
-                    ip = _winreg.QueryValueEx(key, "IPAddress")[0][0]
+                    ip = winreg.QueryValueEx(key, "IPAddress")[0][0]
 
                 pcapy_device = pcapy_device + "\t" + ip
             except Exception:


### PR DESCRIPTION
Use `six` to archive Python 2/3 compatibility when using `winreg` in network monitor.
Fixes #410 

Would be nice if you could test the changes on Windows @FFrozTT. My tests on Ubuntu worked fine.