### PR TITLE
s_bit_field with list of values (as a fuzz library)

### DIFF
--- a/boofuzz/primitives/bit_field.py
+++ b/boofuzz/primitives/bit_field.py
@@ -104,6 +104,10 @@ class BitField(BasePrimitive):
                 # Use the supplied values as the fuzz library.
                 for val in iter(value):
                     self._fuzz_library.append(val)
+
+                # Use the first value of the supplied values as the default value if it exists, 0 else.
+                val = 0 if len(value) == 0 else value[0]
+                self._value = self._original_value = val
             else:
                 # try only "smart" values.
                 self.add_integer_boundaries(0)


### PR DESCRIPTION
If s_bit_field is created with a list of values to be used as the fuzz library, an error in bit_field.py occurs:

```
  File "...\boofuzz\primitives\bit_field.py", line 38, in <lambda>
    return "".join(map(lambda x: str((number >> x) & 1), range(bit_width - 1, -1, -1)))
TypeError: unsupported operand type(s) for >>: 'list' and 'int'
```

Choosing a single value, e.g. the first value in the list, resolves the issue.