### PR TITLE
add BoofuzzFailure to interrupt test case execution on failure...

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,8 @@ Features
 - Added optional timeout and threshold to quit infinite connection retries
 - Reworked Monitors, consolidated interface. Breaking change: session no longer has netmon_options and procmon_options.
 - `SessionInfo` has had attributes renamed; procmon_results and netmon_results are deprecated and now aliases for monitor_results and monitor_data respectively.
+- New `BoofuzzFailure` exception type allows callback methods to signal a failure that should halt the current test case.
+- Fixed many bugs in which a failure would not stop the test case evaluation.
 
 Fixes
 ^^^^^

--- a/boofuzz/__init__.py
+++ b/boofuzz/__init__.py
@@ -24,7 +24,7 @@ from .connections import (
 )
 from .constants import BIG_ENDIAN, DEFAULT_PROCMON_PORT, LITTLE_ENDIAN
 from .event_hook import EventHook
-from .exception import MustImplementException, SizerNotUtilizedError, SullyRuntimeError
+from .exception import MustImplementException, SizerNotUtilizedError, SullyRuntimeError, BoofuzzFailure
 from .fuzz_logger import FuzzLogger
 from .fuzz_logger_csv import FuzzLoggerCsv
 from .fuzz_logger_curses import FuzzLoggerCurses
@@ -67,6 +67,7 @@ __all__ = [
     "BitField",
     "Block",
     "blocks",
+    "BoofuzzFailure",
     "Byte",
     "Bytes",
     "CallbackMonitor",

--- a/boofuzz/exception.py
+++ b/boofuzz/exception.py
@@ -9,8 +9,10 @@ class BoofuzzFailure(Exception):
     it may be necessary to abort the test case before a fuzz message is even sent, as the fuzz message may be poorly
     defined outside the context of a valid partial protocol exchange.
     """
+
     message = attr.ib(type=str, default="")
     pass
+
 
 class BoofuzzError(Exception):
     pass

--- a/boofuzz/exception.py
+++ b/boofuzz/exception.py
@@ -1,6 +1,17 @@
 import attr
 
 
+@attr.s
+class BoofuzzFailure(Exception):
+    """Raises a failure in the current test case.
+
+    This is most important when failures in the target may not be noticed until the next test case. In such a situation,
+    it may be necessary to abort the test case before a fuzz message is even sent, as the fuzz message may be poorly
+    defined outside the context of a valid partial protocol exchange.
+    """
+    message = attr.ib(type=str, default="")
+    pass
+
 class BoofuzzError(Exception):
     pass
 

--- a/boofuzz/fuzz_logger_curses.py
+++ b/boofuzz/fuzz_logger_curses.py
@@ -399,8 +399,9 @@ def _progess_bar(current, total, width):
     return title_str + bar_str + percent_str
 
 
-def _render_pad(lines, pad, y_min, x_min, y_max, x_max, max_lines, total_indent_size, auto_scroll,
-                truncate_long_lines=False):
+def _render_pad(
+    lines, pad, y_min, x_min, y_max, x_max, max_lines, total_indent_size, auto_scroll, truncate_long_lines=False
+):
     total_rows = 0
     height = y_max - y_min + 1
     width = x_max - x_min

--- a/boofuzz/fuzz_logger_curses.py
+++ b/boofuzz/fuzz_logger_curses.py
@@ -35,6 +35,14 @@ else:
             stacklevel=2,
         )
 
+COLOR_PAIR_WHITE = 1
+COLOR_PAIR_CYAN = 2
+COLOR_PAIR_RED = 3
+COLOR_PAIR_YELLOW = 4
+COLOR_PAIR_GREEN = 5
+COLOR_PAIR_MAGENTA = 6
+COLOR_PAIR_BLACK = 7
+
 
 class FuzzLoggerCurses(ifuzz_logger_backend.IFuzzLoggerBackend):
     """
@@ -127,13 +135,13 @@ class FuzzLoggerCurses(ifuzz_logger_backend.IFuzzLoggerBackend):
         self._stdscr.nodelay(1)
 
         # Curses color pairs
-        curses.init_pair(1, curses.COLOR_WHITE, -1)
-        curses.init_pair(2, curses.COLOR_CYAN, -1)
-        curses.init_pair(3, curses.COLOR_RED, -1)
-        curses.init_pair(4, curses.COLOR_YELLOW, -1)
-        curses.init_pair(5, curses.COLOR_GREEN, -1)
-        curses.init_pair(6, curses.COLOR_MAGENTA, -1)
-        curses.init_pair(7, curses.COLOR_BLACK, curses.COLOR_WHITE)
+        curses.init_pair(COLOR_PAIR_WHITE, curses.COLOR_WHITE, -1)
+        curses.init_pair(COLOR_PAIR_CYAN, curses.COLOR_CYAN, -1)
+        curses.init_pair(COLOR_PAIR_RED, curses.COLOR_RED, -1)
+        curses.init_pair(COLOR_PAIR_YELLOW, curses.COLOR_YELLOW, -1)
+        curses.init_pair(COLOR_PAIR_GREEN, curses.COLOR_GREEN, -1)
+        curses.init_pair(COLOR_PAIR_MAGENTA, curses.COLOR_MAGENTA, -1)
+        curses.init_pair(COLOR_PAIR_BLACK, curses.COLOR_BLACK, curses.COLOR_WHITE)
 
         # Start thread and restore the original SIGWINCH handler
         self._draw_thread = threading.Thread(name="curses_logger", target=self._draw_screen)
@@ -179,7 +187,7 @@ class FuzzLoggerCurses(ifuzz_logger_backend.IFuzzLoggerBackend):
             + (4 * indent_size + 1 - len(str(self._total_index))) * " "
             + description.strip()
         )
-        self._fail_storage.append([fail_msg.replace("\n", " "), curses.COLOR_RED])
+        self._fail_storage.append([fail_msg.replace("\n", " "), COLOR_PAIR_WHITE])
         self._log_storage.append(helpers.format_log_msg(msg_type="fail", description=description, format_type="curses"))
         self._event_crash = True
         self._event_log = True
@@ -191,7 +199,7 @@ class FuzzLoggerCurses(ifuzz_logger_backend.IFuzzLoggerBackend):
             + (4 * indent_size + 1 - len(str(self._total_index))) * " "
             + description.strip()
         )
-        self._fail_storage.append([fail_msg.replace("\n", " "), curses.COLOR_YELLOW])
+        self._fail_storage.append([fail_msg.replace("\n", " "), COLOR_PAIR_RED])
         self._log_storage.append(
             helpers.format_log_msg(msg_type="error", description=description, format_type="curses")
         )
@@ -429,7 +437,7 @@ def _render_pad(
                         pad.addstr(
                             total_rows,
                             total_indent_size,
-                            lines[i][0][width:][(row * columns) - columns : row * columns],
+                            lines[i][0][width:][(row * columns) - columns: row * columns],
                             curses.color_pair(lines[i][1]),
                         )
                         total_rows += 1

--- a/boofuzz/fuzz_logger_curses.py
+++ b/boofuzz/fuzz_logger_curses.py
@@ -179,7 +179,7 @@ class FuzzLoggerCurses(ifuzz_logger_backend.IFuzzLoggerBackend):
             + (4 * indent_size + 1 - len(str(self._total_index))) * " "
             + description.strip()
         )
-        self._fail_storage.append([fail_msg, 1])
+        self._fail_storage.append([fail_msg.replace("\n", " "), curses.COLOR_RED])
         self._log_storage.append(helpers.format_log_msg(msg_type="fail", description=description, format_type="curses"))
         self._event_crash = True
         self._event_log = True
@@ -191,7 +191,7 @@ class FuzzLoggerCurses(ifuzz_logger_backend.IFuzzLoggerBackend):
             + (4 * indent_size + 1 - len(str(self._total_index))) * " "
             + description.strip()
         )
-        self._fail_storage.append([fail_msg, 3])
+        self._fail_storage.append([fail_msg.replace("\n", " "), curses.COLOR_YELLOW])
         self._log_storage.append(
             helpers.format_log_msg(msg_type="error", description=description, format_type="curses")
         )
@@ -308,6 +308,7 @@ class FuzzLoggerCurses(ifuzz_logger_backend.IFuzzLoggerBackend):
             max_lines=self._max_log_lines,
             total_indent_size=total_indent_size,
             auto_scroll=self._auto_scroll,
+            truncate_long_lines=True,
         )
 
     def _draw_stat(self):
@@ -398,7 +399,8 @@ def _progess_bar(current, total, width):
     return title_str + bar_str + percent_str
 
 
-def _render_pad(lines, pad, y_min, x_min, y_max, x_max, max_lines, total_indent_size, auto_scroll):
+def _render_pad(lines, pad, y_min, x_min, y_max, x_max, max_lines, total_indent_size, auto_scroll,
+                truncate_long_lines=False):
     total_rows = 0
     height = y_max - y_min + 1
     width = x_max - x_min
@@ -417,20 +419,21 @@ def _render_pad(lines, pad, y_min, x_min, y_max, x_max, max_lines, total_indent_
             total_rows += 1
             break
 
-        columns = width - total_indent_size
-        rows = int(ceil(len(lines[i][0][width:]) / columns))
-        if rows >= 1:
-            for row in range(1, rows + 1):
-                if total_rows < max_lines - 1:
-                    pad.addstr(
-                        total_rows,
-                        total_indent_size,
-                        lines[i][0][width:][(row * columns) - columns : row * columns],
-                        curses.color_pair(lines[i][1]),
-                    )
-                    total_rows += 1
-                else:
-                    break
+        if not truncate_long_lines:
+            columns = width - total_indent_size
+            rows = int(ceil(len(lines[i][0][width:]) / columns))
+            if rows >= 1:
+                for row in range(1, rows + 1):
+                    if total_rows < max_lines - 1:
+                        pad.addstr(
+                            total_rows,
+                            total_indent_size,
+                            lines[i][0][width:][(row * columns) - columns : row * columns],
+                            curses.color_pair(lines[i][1]),
+                        )
+                        total_rows += 1
+                    else:
+                        break
 
     if total_rows > height and auto_scroll:
         offset = total_rows - height

--- a/boofuzz/fuzz_logger_curses.py
+++ b/boofuzz/fuzz_logger_curses.py
@@ -437,7 +437,7 @@ def _render_pad(
                         pad.addstr(
                             total_rows,
                             total_indent_size,
-                            lines[i][0][width:][(row * columns) - columns: row * columns],
+                            lines[i][0][width:][(row * columns) - columns : row * columns],
                             curses.color_pair(lines[i][1]),
                         )
                         total_rows += 1

--- a/boofuzz/sessions.py
+++ b/boofuzz/sessions.py
@@ -12,7 +12,7 @@ import time
 import traceback
 import warnings
 import zlib
-from boofuzz.exception import BoofuzzError, BoofuzzFailure
+from .exception import BoofuzzFailure
 from builtins import input
 from io import open
 

--- a/boofuzz/sessions.py
+++ b/boofuzz/sessions.py
@@ -1175,12 +1175,12 @@ class Session(pgraph.Graph):
             if self._ignore_connection_aborted:
                 self._fuzz_data_logger.log_info(msg)
             else:
-                self._fuzz_data_logger.log_fail(msg)
+                raise BoofuzzFailure(msg)
         except exception.BoofuzzSSLError as e:
             if self._ignore_connection_ssl_errors:
                 self._fuzz_data_logger.log_info(str(e))
             else:
-                self._fuzz_data_logger.log_fail(str(e))
+                raise BoofuzzFailure(message=str(e))
 
         try:  # recv
             if self._receive_data_after_each_request:
@@ -1201,14 +1201,14 @@ class Session(pgraph.Graph):
         except exception.BoofuzzTargetConnectionAborted as e:
             msg = constants.ERR_CONN_ABORTED.format(socket_errno=e.socket_errno, socket_errmsg=e.socket_errmsg)
             if self._check_data_received_each_request:
-                self._fuzz_data_logger.log_fail(msg)
+                raise BoofuzzFailure(msg)
             else:
                 self._fuzz_data_logger.log_info(msg)
         except exception.BoofuzzSSLError as e:
             if self._ignore_connection_ssl_errors:
                 self._fuzz_data_logger.log_info(str(e))
             else:
-                self._fuzz_data_logger.log_fail(str(e))
+                raise BoofuzzFailure(str(e))
 
     def transmit_fuzz(self, sock, node, edge, callback_data):
         """Render and transmit a fuzzed node, process callbacks accordingly.
@@ -1237,12 +1237,12 @@ class Session(pgraph.Graph):
             if self._ignore_connection_issues_when_sending_fuzz_data:
                 self._fuzz_data_logger.log_info(msg)
             else:
-                self._fuzz_data_logger.log_fail(msg)
+                raise BoofuzzFailure(msg)
         except exception.BoofuzzSSLError as e:
             if self._ignore_connection_ssl_errors:
                 self._fuzz_data_logger.log_info(str(e))
             else:
-                self._fuzz_data_logger.log_fail(str(e))
+                raise BoofuzzFailure(str(e))
 
         try:  # recv
             if self._receive_data_after_fuzz:
@@ -1255,7 +1255,7 @@ class Session(pgraph.Graph):
         except exception.BoofuzzTargetConnectionAborted as e:
             msg = constants.ERR_CONN_ABORTED.format(socket_errno=e.socket_errno, socket_errmsg=e.socket_errmsg)
             if self._check_data_received_each_request:
-                self._fuzz_data_logger.log_fail(msg)
+                raise BoofuzzFailure(msg)
             else:
                 self._fuzz_data_logger.log_info(msg)
             pass
@@ -1263,7 +1263,7 @@ class Session(pgraph.Graph):
             if self._ignore_connection_ssl_errors:
                 self._fuzz_data_logger.log_info(str(e))
             else:
-                self._fuzz_data_logger.log_fail(str(e))
+                raise BoofuzzFailure(str(e))
 
     def build_webapp_thread(self, port=constants.DEFAULT_WEB_UI_PORT):
         app.session = self

--- a/boofuzz/utils/debugger_thread_simple.py
+++ b/boofuzz/utils/debugger_thread_simple.py
@@ -195,7 +195,7 @@ class DebuggerThreadSimple(threading.Thread):
             return True
         else:
             with open(self.process_monitor.crash_filename, "a") as rec_file:
-                rec_file.write(self.process_monitor.last_synopsis.decode())
+                rec_file.write(self.process_monitor.last_synopsis)
 
             if self.process_monitor.coredump_dir is not None:
                 dest = os.path.join(self.process_monitor.coredump_dir, str(self.process_monitor.test_number))

--- a/boofuzz/utils/process_monitor_pedrpc_server.py
+++ b/boofuzz/utils/process_monitor_pedrpc_server.py
@@ -187,6 +187,9 @@ class ProcessMonitorPedrpcServer(pedrpc.Server):
             self.log("target still running; stopping first...")
             self._stop_target()
             self.log("target stopped")
+            return True
+        else:
+            return False
 
     def _stop_target(self):
         # give the debugger thread a chance to exit.

--- a/boofuzz/utils/process_monitor_pedrpc_server.py
+++ b/boofuzz/utils/process_monitor_pedrpc_server.py
@@ -150,6 +150,7 @@ class ProcessMonitorPedrpcServer(pedrpc.Server):
         @returns True if successful.
         """
         self.log("Starting target...")
+        self._stop_target_if_running()
         self.log("creating debugger thread", 5)
         self.debugger_thread = self.debugger_class(
             self.start_commands,
@@ -174,19 +175,34 @@ class ProcessMonitorPedrpcServer(pedrpc.Server):
         # give the debugger thread a chance to exit.
         time.sleep(1)
 
-        if self.debugger_thread is not None and self.debugger_thread.isAlive():
-            if len(self.stop_commands) < 1:
-                self.debugger_thread.stop_target()
-            else:
-                for command in self.stop_commands:
-                    if command == "TERMINATE_PID":
-                        self.debugger_thread.stop_target()
-                    else:
-                        self.log("Executing stop command: '{0}'".format(command), 2)
-                        os.system(command)
+        if self._target_is_running():
+            self._stop_target()
             self.log("target stopped")
         else:
             self.log("target already stopped")
+
+    def _stop_target_if_running(self):
+        """Stop target, if it is running. Return true if it was running; otherwise false."""
+        if self._target_is_running():
+            self.log("target still running; stopping first...")
+            self._stop_target()
+            self.log("target stopped")
+
+    def _stop_target(self):
+        # give the debugger thread a chance to exit.
+        time.sleep(1)
+        if len(self.stop_commands) < 1:
+            self.debugger_thread.stop_target()
+        else:
+            for command in self.stop_commands:
+                if command == "TERMINATE_PID":
+                    self.debugger_thread.stop_target()
+                else:
+                    self.log("Executing stop command: '{0}'".format(command), 2)
+                    os.system(command)
+
+    def _target_is_running(self):
+        return self.debugger_thread is not None and self.debugger_thread.isAlive()
 
     def restart_target(self):
         """

--- a/boofuzz/web/static/css/boofuzz.css
+++ b/boofuzz/web/static/css/boofuzz.css
@@ -1,3 +1,10 @@
+.summary div {
+  overflow: hidden;
+  display: -webkit-box;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+}
+
 :root {
     --foreground-color:#A0B0B0;
 }


### PR DESCRIPTION
...and fix a string decoding bug in the Unix procmon.

This PR adds `BoofuzzFailure`, an exception that can be thrown when failures are detected to interrupt test case execution and skip to the next test case. This is especially important when the behavior of some messages in the protocol depends on the results from a previous received message. Without a valid response to message 1, message 2 may be poorly defined, hence the need to abort the test case.

Usage: Instead of calling `log_fail()` on the fuzz logger, raise `BoofuzzFailure` with your failure message. The failure will be logged and the test case terminated.

Can be used in protocol definitions, especially in callback methods. Also used internally by boofuzz.