### PR TITLE
Post start target

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,7 @@ Features
 - Reworked Monitors, consolidated interface. Breaking change: session no longer has netmon_options and procmon_options.
 - `SessionInfo` has had attributes renamed; procmon_results and netmon_results are deprecated and now aliases for monitor_results and monitor_data respectively.
 - Added `capture_output` option to process monitor to capture target process stderr/stdout .
+- Added post-start-target callbacks (called every time a target is started or restarted).
 
 Fixes
 ^^^^^

--- a/boofuzz/monitors/base_monitor.py
+++ b/boofuzz/monitors/base_monitor.py
@@ -51,6 +51,10 @@ class BaseMonitor:
         """
         return True
 
+    def post_start_target(self, target=None, fuzz_data_logger=None, session=None):
+        """Called after a target is started or restarted."""
+        return
+
     def retrieve_data(self):
         """
         Called to retrieve data independent of whether the current fuzz node crashed

--- a/boofuzz/sessions.py
+++ b/boofuzz/sessions.py
@@ -779,11 +779,7 @@ class Session(pgraph.Graph):
             self.server_init()
 
         try:
-            for monitor in self.targets[0].monitors:
-                monitor.start_target()
-            for monitor in self.targets[0].monitors:
-                monitor.post_start_target(target=self.targets[0], fuzz_data_logger=self._fuzz_data_logger,
-                                          session=self,)
+            self._start_target(self.targets[0])
 
             if self._reuse_target_connection:
                 self.targets[0].open()
@@ -833,6 +829,16 @@ class Session(pgraph.Graph):
             raise
         finally:
             self._fuzz_data_logger.close_test()
+
+    def _start_target(self, target):
+        started = False
+        for monitor in target.monitors:
+            if monitor.start_target():
+                started = True
+                break
+        if started:
+            for monitor in target.monitors:
+                monitor.post_start_target(target=target, fuzz_data_logger=self._fuzz_data_logger, session=self)
 
     def import_file(self):
         """
@@ -1129,7 +1135,7 @@ class Session(pgraph.Graph):
         if restarted:
             for monitor in target.monitors:
                 monitor.post_start_target(target=self.targets[0], fuzz_data_logger=self._fuzz_data_logger,
-                                          session=self,)
+                                          session=self)
         else:
             self._fuzz_data_logger.log_info(
                 "No reset handler available... sleeping for {} seconds".format(self.restart_sleep_time)

--- a/boofuzz/sessions.py
+++ b/boofuzz/sessions.py
@@ -491,7 +491,9 @@ class Session(pgraph.Graph):
             restart_methods = restart_callbacks
 
         self._callback_monitor = CallbackMonitor(
-            on_pre_send=pre_send_methods, on_post_send=post_test_case_methods, on_restart_target=restart_methods,
+            on_pre_send=pre_send_methods,
+            on_post_send=post_test_case_methods,
+            on_restart_target=restart_methods,
             on_post_start_target=post_start_target_methods,
         )
 
@@ -1134,8 +1136,7 @@ class Session(pgraph.Graph):
 
         if restarted:
             for monitor in target.monitors:
-                monitor.post_start_target(target=self.targets[0], fuzz_data_logger=self._fuzz_data_logger,
-                                          session=self)
+                monitor.post_start_target(target=self.targets[0], fuzz_data_logger=self._fuzz_data_logger, session=self)
         else:
             self._fuzz_data_logger.log_info(
                 "No reset handler available... sleeping for {} seconds".format(self.restart_sleep_time)

--- a/boofuzz/sessions.py
+++ b/boofuzz/sessions.py
@@ -362,6 +362,8 @@ class Session(pgraph.Graph):
                                             Default None.
         post_test_case_callbacks (list of method): The registered method will be called after each fuzz test case.
                                                   Default None.
+        post_start_target_callbacks (list of method): Method(s) will be called after the target is started or restarted,
+                                                      say, by a process monitor.
         web_port (int):         Port for monitoring fuzzing campaign via a web browser. Default 26000.
         keep_web_open (bool):     Keep the webinterface open after session completion. Default True.
         fuzz_loggers (list of ifuzz_logger.IFuzzLogger): For saving test data and results.. Default Log to STDOUT.
@@ -407,6 +409,7 @@ class Session(pgraph.Graph):
         restart_timeout=None,
         pre_send_callbacks=None,
         post_test_case_callbacks=None,
+        post_start_target_callbacks=None,
         fuzz_loggers=None,
         fuzz_db_keep_only_n_pass_cases=0,
         receive_data_after_each_request=True,
@@ -477,13 +480,19 @@ class Session(pgraph.Graph):
         else:
             post_test_case_methods = post_test_case_callbacks
 
+        if post_start_target_callbacks is None:
+            post_start_target_methods = []
+        else:
+            post_start_target_methods = post_start_target_callbacks
+
         if restart_callbacks is None:
             restart_methods = []
         else:
             restart_methods = restart_callbacks
 
         self._callback_monitor = CallbackMonitor(
-            on_pre_send=pre_send_methods, on_post_send=post_test_case_methods, on_restart_target=restart_methods
+            on_pre_send=pre_send_methods, on_post_send=post_test_case_methods, on_restart_target=restart_methods,
+            on_post_start_target=post_start_target_methods,
         )
 
         self.total_num_mutations = 0
@@ -772,6 +781,9 @@ class Session(pgraph.Graph):
         try:
             for monitor in self.targets[0].monitors:
                 monitor.start_target()
+            for monitor in self.targets[0].monitors:
+                monitor.post_start_target(target=self.targets[0], fuzz_data_logger=self._fuzz_data_logger,
+                                          session=self,)
 
             if self._reuse_target_connection:
                 self.targets[0].open()
@@ -1092,18 +1104,19 @@ class Session(pgraph.Graph):
         #       a custom callback. wtf?
 
         self._fuzz_data_logger.open_test_step("Restarting target")
+        restarted = False
         if len(self.on_failure) > 0:
             for f in self.on_failure:
                 self._fuzz_data_logger.open_test_step("Calling registered on_failure method")
                 f(logger=self._fuzz_data_logger)
+            restarted = True
         # vm restarting is the preferred method so try that before monitors.
         elif target.vmcontrol:
             self._fuzz_data_logger.log_info("Restarting target virtual machine")
             target.vmcontrol.restart_target()
-
+            restarted = True
         # we always have at least one monitor; a Callback Monitor that handles all callbacks.
         else:
-            restarted = False
             for monitor in target.monitors:
                 self._fuzz_data_logger.log_info("Restarting target process using {}".format(monitor.__class__.__name__))
                 if monitor.restart_target(target=target, fuzz_data_logger=self._fuzz_data_logger, session=self):
@@ -1113,12 +1126,15 @@ class Session(pgraph.Graph):
                     restarted = True
                     break
 
-            # no monitor can restart
-            if not restarted:
-                self._fuzz_data_logger.log_info(
-                    "No reset handler available... sleeping for {} seconds".format(self.restart_sleep_time)
-                )
-                time.sleep(self.restart_sleep_time)
+        if restarted:
+            for monitor in target.monitors:
+                monitor.post_start_target(target=self.targets[0], fuzz_data_logger=self._fuzz_data_logger,
+                                          session=self,)
+        else:
+            self._fuzz_data_logger.log_info(
+                "No reset handler available... sleeping for {} seconds".format(self.restart_sleep_time)
+            )
+            time.sleep(self.restart_sleep_time)
 
         # pass specified target parameters to the PED-RPC server to re-establish connections.
         target.monitors_alive()


### PR DESCRIPTION
Added `Session.__init__` `post_start_target_callbacks`, called every time a target is started or restarted. Handy for handling execution-specific behavior of a target.

Thanks to @mistressofjellyfish for setting up the infrastructure to make this an easy add.