### PR TITLE
Prevent duplicate CI builds

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,8 @@ name: Test
 
 on:
   push:
+    branches:
+      - master
   pull_request:
   schedule:
     - cron:  '0 0 * * 0' # @weekly


### PR DESCRIPTION
Disable test workflow when pushing to non master branch. Tests are still performed when creating a PR.
This should help to reduce the amount of duplicate builds on the same commit.