### PR TITLE
simple debugger: check for crashes in get_crash_synopsis()

### DIFF
--- a/boofuzz/utils/process_monitor_pedrpc_server.py
+++ b/boofuzz/utils/process_monitor_pedrpc_server.py
@@ -104,6 +104,8 @@ class ProcessMonitorPedrpcServer(pedrpc.Server):
         @rtype:  String
         @return: Synopsis of last recorded crash.
         """
+        # Since crash synopsis is called only after a failure, check for failures again:
+        self.debugger_thread.post_send()
 
         return self.last_synopsis
 


### PR DESCRIPTION
In the case where crashes are not immediately detected, I was failing to get reliable reports from the simple procmon (Unix). Two changes to fix:

1. `Session._check_for_passively_detected_failures()` now has an argument to signal a failure has been detected apart from any monitors. This forces the method to call `get_crash_synopsis()`. This matches the intention from PR #385, I believe.
2. The procmon server now checks `post_send` when `get_crash_synopsis()` is called. Note: This might result in double reporting in some other use cases, but that can be fixed as needed.

Bonus: Got rid of the `_check_for_passively_detected_failures()` double calls. IIRC, #385 made this effectively no longer necessary. (Tagging @mistressofjellyfish @SR4ven in case they remember otherwise)