### PR TITLE
Fix docs favicon.svg path

### DIFF
--- a/docs/_templates/layout.html
+++ b/docs/_templates/layout.html
@@ -1,5 +1,5 @@
 {% extends "!layout.html" %}
 {% block linktags %}
-    <link rel="icon" type="image/svg+xml" href="_static/favicon.svg" sizes="any">
+    <link rel="icon" type="image/svg+xml" href="{{ pathto('_static/favicon.svg', 1) }}" sizes="any">
     {{ super() }}
 {% endblock %}


### PR DESCRIPTION
When accessing a subpage on the docs the path to the favicon was invalid.
Using [pathto()](https://www.sphinx-doc.org/en/master/templating.html#pathto) fixes this.