### PR TITLE
Memory optimization fix for s_string

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -35,6 +35,7 @@ Fixes
 - Removed deprecated logger `FuzzLoggerFile`.
 - Fixed network monitor compatibility with Python 3.
 - Minor console GUI optimizations.
+- Fixed memory optimization for `s_string`
 
 v0.1.6
 ------

--- a/boofuzz/primitives/string.py
+++ b/boofuzz/primitives/string.py
@@ -279,7 +279,7 @@ class String(BasePrimitive):
                 return False
 
             # update the current value from the fuzz library.
-            self._value = (self._fuzz_library + self.this_library)[self._mutant_index]
+            self._value = ((self._fuzz_library or String._fuzz_library) + self.this_library)[self._mutant_index]
 
             # increment the mutation count.
             self._mutant_index += 1
@@ -302,7 +302,7 @@ class String(BasePrimitive):
         @rtype:  int
         @return: Number of mutated forms this primitive can take
         """
-        return len(self._fuzz_library) + len(self.this_library)
+        return len(self._fuzz_library or String._fuzz_library) + len(self.this_library)
 
     def _render(self, value):
         """

--- a/boofuzz/primitives/string.py
+++ b/boofuzz/primitives/string.py
@@ -230,7 +230,7 @@ class String(BasePrimitive):
                 self.this_library = list(set([t[: self.max_len] for t in self.this_library]))
             if any(len(s) > self.max_len for s in String._fuzz_library):
                 # Pull out the bad string(s):
-                String._fuzz_library = list(set([t[: self.max_len] for t in String._fuzz_library]))
+                self._fuzz_library = list(set([t[: self.max_len] for t in String._fuzz_library]))
 
     @property
     def name(self):
@@ -279,7 +279,7 @@ class String(BasePrimitive):
                 return False
 
             # update the current value from the fuzz library.
-            self._value = (String._fuzz_library + self.this_library)[self._mutant_index]
+            self._value = (self._fuzz_library + self.this_library)[self._mutant_index]
 
             # increment the mutation count.
             self._mutant_index += 1
@@ -302,7 +302,7 @@ class String(BasePrimitive):
         @rtype:  int
         @return: Number of mutated forms this primitive can take
         """
-        return len(String._fuzz_library) + len(self.this_library)
+        return len(self._fuzz_library) + len(self.this_library)
 
     def _render(self, value):
         """

--- a/boofuzz/primitives/string.py
+++ b/boofuzz/primitives/string.py
@@ -59,8 +59,8 @@ class String(BasePrimitive):
             self._value * 10 + b"\xfe",
             self._value * 100 + b"\xfe",
         ]
-        if not self._fuzz_library:
-            self._fuzz_library = [
+        if not String._fuzz_library:
+            String._fuzz_library = [
                 "",
                 # strings ripped from spike (and some others I added)
                 "/.:/" + "A" * 5000 + "\x00\x00",
@@ -219,7 +219,7 @@ class String(BasePrimitive):
                     # Location of random byte
                     loc = random.randint(1, len(s))
                     s = s[:loc] + "\x00" + s[loc:]
-                self._fuzz_library.append(s)
+                String._fuzz_library.append(s)
 
                 # TODO: Add easy and sane string injection from external file/s
 
@@ -228,9 +228,9 @@ class String(BasePrimitive):
             if any(len(s) > self.max_len for s in self.this_library):
                 # Pull out the bad string(s):
                 self.this_library = list(set([t[: self.max_len] for t in self.this_library]))
-            if any(len(s) > self.max_len for s in self._fuzz_library):
+            if any(len(s) > self.max_len for s in String._fuzz_library):
                 # Pull out the bad string(s):
-                self._fuzz_library = list(set([t[: self.max_len] for t in self._fuzz_library]))
+                String._fuzz_library = list(set([t[: self.max_len] for t in String._fuzz_library]))
 
     @property
     def name(self):
@@ -256,7 +256,7 @@ class String(BasePrimitive):
             strings.append(sequence * size)
 
         for string in strings:
-            self._fuzz_library.append(string)
+            String._fuzz_library.append(string)
 
     def mutate(self):
         """
@@ -279,7 +279,7 @@ class String(BasePrimitive):
                 return False
 
             # update the current value from the fuzz library.
-            self._value = (self._fuzz_library + self.this_library)[self._mutant_index]
+            self._value = (String._fuzz_library + self.this_library)[self._mutant_index]
 
             # increment the mutation count.
             self._mutant_index += 1
@@ -302,7 +302,7 @@ class String(BasePrimitive):
         @rtype:  int
         @return: Number of mutated forms this primitive can take
         """
-        return len(self._fuzz_library) + len(self.this_library)
+        return len(String._fuzz_library) + len(self.this_library)
 
     def _render(self, value):
         """


### PR DESCRIPTION
The `String` class has the class attribute `_fuzz_library` to share a huge part of the library between instances and save a lot of memory as is mentioned in a comment:

> store fuzz_library as a class variable to avoid copying the ~70MB structure across each instantiated primitive.

Currently this does not work, because `_fuzz_library` is not updated as a class attribute (shared between all instances) but as an instance attribute (not shared). Therefore each use of `s_string` initialises it's own `_fuzz_library` and allocates additional ~70MB of memory.

To demonstrate this:
```
# test_str.py
import sys, os, psutil
from boofuzz import *

before = psutil.Process(os.getpid()).memory_info().rss
s_initialize(name="test")
for i in range(int(sys.argv[1])):
  s_string('')
after = psutil.Process(os.getpid()).memory_info().rss
print('%.2fMB'%((after-before)/1024**2))
```

With current master:
```
$ python3 test_str.py 1
63.14MB
$ python3 ./test_str.py 10
631.70MB
```
After this fix:
```
$ python3 test_str.py 1
63.14MB
$ python3 ./test_str.py 10
63.14MB
$ python3 ./test_str.py 1000
63.65MB
```
