### PR TITLE
Fix behaviour of skip_element on blocks

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -35,6 +35,7 @@ Fixes
 - Removed deprecated logger `FuzzLoggerFile`.
 - Fixed network monitor compatibility with Python 3.
 - Minor console GUI optimizations.
+- Fixed crash_threshold_element handling if blocks are used
 
 v0.1.6
 ------

--- a/boofuzz/blocks/request.py
+++ b/boofuzz/blocks/request.py
@@ -86,8 +86,13 @@ class Request(IFuzzable):
         return mutated
 
     def skip_element(self):
-        self.stack[self._element_mutant_index].reset()
-        self._element_mutant_index += 1
+        item = self.stack[self._element_mutant_index]
+        if isinstance(item, Block):
+            item.skip_element()
+        else:
+            item.reset()
+            self._element_mutant_index += 1
+
 
     def num_mutations(self):
         """

--- a/unit_tests/test_blocks.py
+++ b/unit_tests/test_blocks.py
@@ -197,13 +197,14 @@ class TestBlocks(unittest.TestCase):
 
         req = s_get("SKIP TEST")
         req.mutate()
-        self.assertEqual(req.mutant.name, 'foo')
+        self.assertEqual(req.mutant.name, "foo")
         req.skip_element()
         req.mutate()
-        self.assertEqual(req.mutant.name, 'bar')
+        self.assertEqual(req.mutant.name, "bar")
         req.skip_element()
         req.mutate()
-        self.assertEqual(req.mutant.name, 'baz')
+        self.assertEqual(req.mutant.name, "baz")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/unit_tests/test_blocks.py
+++ b/unit_tests/test_blocks.py
@@ -187,6 +187,23 @@ class TestBlocks(unittest.TestCase):
         self.assertEqual(req.num_mutations(), 0)
         self.assertEqual(req.render(), b"test")
 
+    def test_skip_element(self):
+        s_initialize("SKIP TEST")
+
+        with s_block("BLOCK1") as b:
+            s_string("foo", name="foo")
+            s_string("bar", name="bar")
+        s_string("baz", name="baz")
+
+        req = s_get("SKIP TEST")
+        req.mutate()
+        self.assertEqual(req.mutant.name, 'foo')
+        req.skip_element()
+        req.mutate()
+        self.assertEqual(req.mutant.name, 'bar')
+        req.skip_element()
+        req.mutate()
+        self.assertEqual(req.mutant.name, 'baz')
 
 if __name__ == "__main__":
     unittest.main()

--- a/unit_tests/test_blocks.py
+++ b/unit_tests/test_blocks.py
@@ -190,7 +190,7 @@ class TestBlocks(unittest.TestCase):
     def test_skip_element(self):
         s_initialize("SKIP TEST")
 
-        with s_block("BLOCK1") as b:
+        with s_block("BLOCK1"):
             s_string("foo", name="foo")
             s_string("bar", name="bar")
         s_string("baz", name="baz")


### PR DESCRIPTION
Currently if `Request.skip_element` is called while the current mutant is a primitive **inside a block**, the whole block is skipped instead of only the primitive. This is noticable when `crash_threshold_element` is exceeded on such a primitive. In this case `total_mutant_index` is advanced as if only the primitive is skipped while actually more cases are skipped, so this behaviour is inconsistent and messes up test case numbering. See also the test case I've added for what I think would be the correct behaviour.

My change basically copies the code related to `skip_element` and `_element_mutant_index` tracking from the `Request` to the `Block` class (cf. 458ed968) and recurses through all blocks until a primitive is reached.

A much simpler approach to `skip_element` in general would be to simply mutate the current mutant until it is exhausted:
```
class Request(IFuzzable):
    # ...
    def skip_element(self):
        while self.mutant.mutate():
            pass
```
This way the whole code for tracking `_element_mutant_index` could be removed with an IMHO insignificant performance impact. If you prefer this approach, I would update the PR accordingly.