### PR TITLE
Import crc32c only if needed

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -36,6 +36,7 @@ Fixes
 - Fixed network monitor compatibility with Python 3.
 - Minor console GUI optimizations.
 - Fixed crash_threshold_element handling if blocks are used
+- `crc32c` is no longer a required package. Install manually if needed.
 
 v0.1.6
 ------

--- a/boofuzz/blocks/checksum.py
+++ b/boofuzz/blocks/checksum.py
@@ -4,13 +4,6 @@ import warnings
 import zlib
 from functools import wraps
 
-try:
-    import crc32c  # pytype: disable=import-error
-except ImportError:
-    # Import guard for systems without crc32c support.
-    warnings.warn("Importing crc32c package failed. Using crc32c checksums will fail.", UserWarning, stacklevel=2)
-    crc32c = None
-    pass
 import six
 
 from .. import exception, helpers, primitives
@@ -151,6 +144,13 @@ class Checksum(primitives.BasePrimitive):
                 check = struct.pack(self._endian + "L", (zlib.crc32(data) & 0xFFFFFFFF))
 
             elif self._algorithm == "crc32c":
+                try:
+                    import crc32c  # pytype: disable=import-error
+                except ImportError:
+                    warnings.warn(
+                        "Importing crc32c package failed. Please install it using pip.", UserWarning, stacklevel=2
+                    )
+                    raise
                 check = struct.pack(self._endian + "L", crc32c.crc32(data))
 
             elif self._algorithm == "adler32":

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,6 @@ setup(
         "backports.shutil_get_terminal_size",
         "click",
         "colorama",
-        "crc32c",
         "Flask",
         "future",
         "impacket",


### PR DESCRIPTION
As discussed in #436, `crc32c` is removed from the requirements. Fixes #436 

Implementation stays in place but will fail with import error if `crc32c` algorithm is specified but package is not present.