### PR TITLE
Fix test_target for inaccurate sleep times

### DIFF
--- a/unit_tests/test_target.py
+++ b/unit_tests/test_target.py
@@ -8,8 +8,8 @@ from boofuzz.connections import ITargetConnection
 class MockCountConnection(ITargetConnection):
     def __init__(self):
         self.count = 0
-        self.first = None
-        self.second = None
+        self.first = 0
+        self.second = 0
 
     def close(self):
         pass
@@ -22,9 +22,9 @@ class MockCountConnection(ITargetConnection):
 
     def send(self, data):
         self.count += 1
-        if self.first is None:
+        if self.first == 0:
             self.first = time.time()
-        elif self.second is None:
+        elif self.second == 0:
             self.second = time.time()
 
     @property
@@ -34,9 +34,9 @@ class MockCountConnection(ITargetConnection):
 
 class MockTimeConnection(ITargetConnection):
     def __init__(self):
-        self.first = None
-        self.second = None
-        self.last = None
+        self.first = 0
+        self.second = 0
+        self.last = 0
 
     def close(self):
         pass
@@ -48,9 +48,9 @@ class MockTimeConnection(ITargetConnection):
         pass
 
     def send(self, data):
-        if self.first is None:
+        if self.first == 0:
             self.first = time.time()
-        elif self.second is None:
+        elif self.second == 0:
             self.second = time.time()
         self.last = time.time()
 

--- a/unit_tests/test_target.py
+++ b/unit_tests/test_target.py
@@ -70,7 +70,7 @@ class TestTarget(unittest.TestCase):
         target.send(b"This is a test")
 
         self.assertEqual(repeater.count, connection.count)
-        self.assertGreaterEqual(connection.second - connection.first, self.SLEEP_TIME)
+        self.assertGreaterEqual(round(connection.second - connection.first, 2), self.SLEEP_TIME)
         with self.assertRaises(ValueError):
             CountRepeater(count=0)
 
@@ -82,6 +82,6 @@ class TestTarget(unittest.TestCase):
         target.send(b"This is a test")
 
         self.assertLessEqual(connection.last - connection.first, repeater.duration)
-        self.assertGreaterEqual(connection.second - connection.first, self.SLEEP_TIME)
+        self.assertGreaterEqual(round(connection.second - connection.first, 2), self.SLEEP_TIME)
         with self.assertRaises(ValueError):
             TimeRepeater(duration=0)


### PR DESCRIPTION
The weekly test failed on Windows as the actual sleep time was shorter than expected one for the target unit tests.
See https://github.com/jtpereyda/boofuzz/runs/792499474?check_suite_focus=true#step:7:57

Apparently the sleep function isn't as accurate on Windows as it is on Linux, at least for Python 2. Rounding the time to 2 decimal places should fix this.