### PR TITLE
Fix UDPSocketConnection data truncation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+Upcoming
+--------
+Features
+^^^^^^^^
+
+Fixes
+^^^^^
+- Fixed UDPSocketConnection data truncation when sending more data than the socket supports.
+
 v0.2.0
 ------
 Features

--- a/boofuzz/connections/udp_socket_connection.py
+++ b/boofuzz/connections/udp_socket_connection.py
@@ -116,7 +116,7 @@ class UDPSocketConnection(base_socket_connection.BaseSocketConnection):
             int: Number of bytes actually sent.
         """
         num_sent = 0
-        data = data[:self._max_payload]
+        data = data[: self._max_payload]
 
         try:
             if self.server:

--- a/boofuzz/connections/udp_socket_connection.py
+++ b/boofuzz/connections/udp_socket_connection.py
@@ -42,6 +42,8 @@ class UDPSocketConnection(base_socket_connection.BaseSocketConnection):
         self._serverSock = None
         self._udp_client_port = None
 
+        self.max_payload()
+
         if self.bind and self.server:
             raise Exception("You cannot set both bind and server at the same time.")
 
@@ -114,6 +116,7 @@ class UDPSocketConnection(base_socket_connection.BaseSocketConnection):
             int: Number of bytes actually sent.
         """
         num_sent = 0
+        data = data[:self._max_payload]
 
         try:
             if self.server:


### PR DESCRIPTION
`send()` now correctly truncates the data before sending using `max_payload()`.

Fixes #443 

@JamesHagerman can you test if this resolves your problem please?