### PR TITLE
Fix execution of procmon stop_commands

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,6 +9,7 @@ Features
 Fixes
 ^^^^^
 - Fixed UDPSocketConnection data truncation when sending more data than the socket supports.
+- Fixed execution of procmon stop_commands.
 
 v0.2.0
 ------

--- a/boofuzz/monitors/pedrpc.py
+++ b/boofuzz/monitors/pedrpc.py
@@ -256,7 +256,7 @@ class Server(object):
             try:
                 self.__client_sock.shutdown(socket.SHUT_RDWR)
             except socket.error as e:
-                if e.errno == errno.ENOTCONN:
+                if e.errno in [errno.ENOTCONN, errno.EBADF]:
                     pass
                 else:
                     raise

--- a/boofuzz/utils/process_monitor_pedrpc_server.py
+++ b/boofuzz/utils/process_monitor_pedrpc_server.py
@@ -2,6 +2,7 @@ from __future__ import print_function
 
 import os
 import shlex
+import subprocess
 import time
 
 from builtins import str
@@ -177,8 +178,6 @@ class ProcessMonitorPedrpcServer(pedrpc.Server):
         Kill the current debugger thread and stop the target process by issuing the commands in self.stop_commands.
         """
         self.log("Stopping target...")
-        # give the debugger thread a chance to exit.
-        time.sleep(1)
 
         if self._target_is_running():
             self._stop_target()
@@ -201,13 +200,17 @@ class ProcessMonitorPedrpcServer(pedrpc.Server):
         time.sleep(1)
         if len(self.stop_commands) < 1:
             self.debugger_thread.stop_target()
+            while self.debugger_thread.isAlive():
+                time.sleep(0.1)
         else:
             for command in self.stop_commands:
                 if command == "TERMINATE_PID":
                     self.debugger_thread.stop_target()
+                    while self.debugger_thread.isAlive():
+                        time.sleep(0.1)
                 else:
                     self.log("Executing stop command: '{0}'".format(command), 2)
-                    os.system(command)
+                    subprocess.Popen(command)
 
     def _target_is_running(self):
         return self.debugger_thread is not None and self.debugger_thread.isAlive()

--- a/boofuzz/utils/process_monitor_pedrpc_server.py
+++ b/boofuzz/utils/process_monitor_pedrpc_server.py
@@ -204,7 +204,7 @@ class ProcessMonitorPedrpcServer(pedrpc.Server):
                 time.sleep(0.1)
         else:
             for command in self.stop_commands:
-                if command == "TERMINATE_PID":
+                if command == ["TERMINATE_PID"] or command == "TERMINATE_PID":
                     self.debugger_thread.stop_target()
                     while self.debugger_thread.isAlive():
                         time.sleep(0.1)


### PR DESCRIPTION
Fixes #445 

Would be nice if you could verify that this works @tjzhang1.

> Changed if command == "TERMINATE_PID" to `if command == ["TERMINATE_PID"]' because stop commands are stored as lists of strings

This didn't work for me. `command` is not a list, just `stop_commands` is, so I left this unchanged.
Please correct me if I've missed something here.