### PR TITLE
Fix TCP and SSL server connections

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ Fixes
 ^^^^^
 - Fixed UDPSocketConnection data truncation when sending more data than the socket supports.
 - Fixed execution of procmon stop_commands.
+- Fixed TCP and SSL server connections.
 
 v0.2.0
 ------

--- a/boofuzz/connections/ssl_socket_connection.py
+++ b/boofuzz/connections/ssl_socket_connection.py
@@ -37,8 +37,6 @@ class SSLSocketConnection(tcp_socket_connection.TCPSocketConnection):
             raise ValueError("SSL/TLS requires either sslcontext or server_hostname to be set.")
 
     def open(self):
-        super(SSLSocketConnection, self).open()
-
         # If boofuzz is the SSL client and user did not give us a SSLContext,
         # then we just use a default one.
         if self.server is False and self.sslcontext is None:
@@ -46,12 +44,7 @@ class SSLSocketConnection(tcp_socket_connection.TCPSocketConnection):
             self.sslcontext.check_hostname = True
             self.sslcontext.verify_mode = ssl.CERT_REQUIRED
 
-        try:
-            self._sock = self.sslcontext.wrap_socket(
-                self._sock, server_side=self.server, server_hostname=self.server_hostname
-            )
-        except ssl.SSLError as e:
-            raise exception.BoofuzzTargetConnectionFailedError(str(e))
+        super(SSLSocketConnection, self).open()
 
     def recv(self, max_bytes):
         """

--- a/boofuzz/connections/tcp_socket_connection.py
+++ b/boofuzz/connections/tcp_socket_connection.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import
 import errno
 import socket
 import sys
-import ssl
 
 from future.utils import raise_
 
@@ -40,23 +39,16 @@ class TCPSocketConnection(base_socket_connection.BaseSocketConnection):
             self._serverSock.close()
 
     def open(self):
+        self._open_socket()
+        self._connect_socket()
+
+    def _open_socket(self):
         self._sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 
         # call superclass to set timeout sockopt
         super(TCPSocketConnection, self).open()
 
-        # Create SSL socket
-        try:
-            self._sock = self.sslcontext.wrap_socket(
-                self._sock, server_side=self.server, server_hostname=self.server_hostname
-            )
-        except ssl.SSLError as e:
-            self.close()
-            raise exception.BoofuzzTargetConnectionFailedError(str(e))
-        except AttributeError:
-            # No SSL context set
-            pass
-
+    def _connect_socket(self):
         if self.server:
             self._sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
             try:


### PR DESCRIPTION
Fixes #449 

Turns out fixing this wasn't too much work after all. The main problem was the SSL socket wrapping which wasn't in the right place.

It kinda bothers me that we have SSL related code in `TCPSocketConnection` now but I couldn't think of any other way. A callback might be an option if you prefer that over the current solution @jtpereyda.

Would be nice if you verify that this fixes your problem @hrantzsch