### PR TITLE
s_group: fix str input and unit_test for same

### DIFF
--- a/boofuzz/primitives/group.py
+++ b/boofuzz/primitives/group.py
@@ -4,7 +4,7 @@ from .base_primitive import BasePrimitive
 
 
 class Group(BasePrimitive):
-    def __init__(self, name, values, default_value=None, *args, **kwargs):
+    def __init__(self, name, values, default_value=None, encoding="ascii", *args, **kwargs):
         """
         This primitive represents a list of static values, stepping through each one on mutation. You can tie a block
         to a group primitive to specify that the block should cycle through all possible mutations for *each* value
@@ -16,15 +16,19 @@ class Group(BasePrimitive):
         @param values:          List of possible raw values this group can take.
 
         @param default_value:   Specifying a value when fuzzing() is complete
+        @type  encoding:        str
+        @param encoding:        (Optional, def="ascii") String encoding, ex: utf_16_le for Microsoft Unicode.
         """
+        assert len(values) > 0, "You can't have an empty value list for your group!"
+        for val in values:
+            assert isinstance(val, (six.binary_type, six.string_types)), "Value list may only contain string/byte types"
+        values = list(map(lambda value: value if isinstance(value, bytes) else value.encode(encoding=encoding), values))
+
         if default_value is None:
             default_value = values[0]
         super(Group, self).__init__(name, default_value, *args, **kwargs)
 
         self.values = values
-        assert len(self.values) > 0, "You can't have an empty value list for your group!"
-        for val in self.values:
-            assert isinstance(val, (six.binary_type, six.string_types)), "Value list may only contain string/byte types"
 
     def mutations(self, default_value):
         for value in self.values:

--- a/boofuzz/primitives/group.py
+++ b/boofuzz/primitives/group.py
@@ -26,6 +26,8 @@ class Group(BasePrimitive):
 
         if default_value is None:
             default_value = values[0]
+        default_value = default_value if isinstance(default_value, bytes) else default_value.encode(encoding=encoding)
+
         super(Group, self).__init__(name, default_value, *args, **kwargs)
 
         self.values = values

--- a/unit_tests/test_s_group.feature
+++ b/unit_tests/test_s_group.feature
@@ -1,0 +1,13 @@
+Feature: test_s_group
+
+    Scenario: test_s_group_byte
+        Given Scenario with byte can be defined
+        When Scenario can be rendered
+        Then Scenario output is 0x06
+        And Scenario can render all mutations
+
+    Scenario: test_s_group_str
+        Given Scenario with str can be defined
+        When Scenario can be rendered
+        Then Scenario output is 0x06
+        And Scenario can render all mutations

--- a/unit_tests/test_s_group.py
+++ b/unit_tests/test_s_group.py
@@ -11,14 +11,14 @@ scenarios("test_s_group.feature")
 @given("Scenario with str can be defined")
 def scenario_with_str_can_be_defined(context):
     s_initialize("test_s_group_str")
-    s_group("1_group_str", values=["\x06"])
+    s_group("1_group_str", values=["\x06"], default_value="\x06")
     context.req = s_get("test_s_group_str")
 
 
 @given("Scenario with byte can be defined")
 def scenario_with_byte_can_be_defined(context):
     s_initialize("test_s_group_byte")
-    s_group("1_group_byte", values=[b"\x06"])
+    s_group("1_group_byte", values=[b"\x06"], default_value=b"\x06")
     context.req = s_get("test_s_group_byte")
 
 

--- a/unit_tests/test_s_group.py
+++ b/unit_tests/test_s_group.py
@@ -1,0 +1,39 @@
+import struct
+
+from pytest_bdd import given, parsers, scenarios, then, when
+
+from boofuzz import *
+from boofuzz.mutation_context import MutationContext
+
+scenarios("test_s_group.feature")
+
+
+@given("Scenario with str can be defined")
+def scenario_with_str_can_be_defined(context):
+    s_initialize("test_s_group_str")
+    s_group("1_group_str", values=["\x06"])
+    context.req = s_get("test_s_group_str")
+
+
+@given("Scenario with byte can be defined")
+def scenario_with_byte_can_be_defined(context):
+    s_initialize("test_s_group_byte")
+    s_group("1_group_byte", values=[b"\x06"])
+    context.req = s_get("test_s_group_byte")
+
+
+@when("Scenario can be rendered")
+def scenario_can_be_rendered(context):
+    context.output = context.req.render()
+
+
+@then(parsers.parse("Scenario output is 0x{value:x}"))
+def scenario_output_is(context, value):
+    assert context.output == struct.pack("B", value)
+
+
+@then("Scenario can render all mutations")
+def scenario_can_render_all_mutations(context):
+    mutations = list(context.req.get_mutations())
+    for mutation in mutations:
+        context.req.render(MutationContext(mutation=mutation))


### PR DESCRIPTION
s_group is currently broken when fed a list of strings.

`fuzzable_block.py/get_child_data()` does `rendered += item.render(mutation_context=mutation_context)` and this breaks with `TypeError: can't concat str to bytes`

But s_group specifically accepts str as input:
`assert isinstance(val, (six.binary_type, six.string_types)), "Value list may only contain string/byte types"`

I see the following solutions:

1. Only allow bytes as input for `s_group()` values.
2. s_group coerces all input to bytes during `__init__`
3. `fuzzable_block.py get_child_data()` coerces all input to bytes

I fixed a similar problem in `s_checksum()` before: https://github.com/jtpereyda/boofuzz/pull/453/commits/93eb7e1dea910e294adce1e70d957a699ebc3872

What do you think?