### PR TITLE
checksum: normalize block_name resolving

### DIFF
--- a/boofuzz/blocks/checksum.py
+++ b/boofuzz/blocks/checksum.py
@@ -115,7 +115,7 @@ class Checksum(primitives.BasePrimitive):
     @_may_recurse
     def _render_block(self, block_name, mutation_context):
         return (
-            self._request.names[block_name].render(mutation_context=mutation_context)
+            self._request.resolve_name(self.context_path, block_name).render(mutation_context=mutation_context)
             if block_name is not None
             else None
         )

--- a/unit_tests/test_checksum_original_value.py
+++ b/unit_tests/test_checksum_original_value.py
@@ -20,7 +20,7 @@ def a_checksum(context):
     block.push(byte2)
 
     checksum = Checksum(
-        block_name="unit-test-request.unit-test-block", request=request, fuzzable=True, name="Checksum block"
+        block_name="unit-test-block", request=request, fuzzable=True, name="Checksum block"
     )
     request.push(checksum)
 
@@ -46,7 +46,7 @@ def udp_checksum(context):
     request.push(ipv4_dst)
 
     checksum = Checksum(
-        block_name="unit-test-request.unit-test-block.IPv4 Packet",
+        block_name="IPv4 Packet",
         ipv4_src_block_name="IPv4 Src Block",
         ipv4_dst_block_name="IPv4 Dst Block",
         request=request,

--- a/unit_tests/test_s_checksum.py
+++ b/unit_tests/test_s_checksum.py
@@ -12,7 +12,7 @@ scenarios("test_s_checksum.feature")
 def scenario_can_be_defined(context):
     s_initialize("test_s_checksum")
     s_static(b"\x00", name="1_static_byte")
-    s_checksum("test_s_checksum.1_static_byte")
+    s_checksum("1_static_byte")
     context.req = s_get("test_s_checksum")
 
 


### PR DESCRIPTION
`s_checksum` syntax had changed to use a full path name for `block_name`, in contrast to `s_size`, `s_repeat`, etc.
changed to their behaviour
