### PR TITLE
Fix data_bytes calculation (wait for PcapThread)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Features
 - Protocol definition: Protocols can now be defined with an object oriented rather than static approach.
 - Independent mutation and encoding steps: Will enable multiple mutations and code coverage feedback.
 - Procmon: Additional debug steps. Partial backwards compatibility for old interface.
+- Network monitor: improved network interface discovery (Linux support)
 
 
 Fixes
@@ -21,6 +22,7 @@ Fixes
 - Various web interface fixes.
 - Various refactors and simplifications.
 - Fewer duplicates from `Group` primitives.
+- Network monitor: fixed data_bytes calculation and PcapThread synchronization
 
 v0.2.1
 ------

--- a/network_monitor.py
+++ b/network_monitor.py
@@ -1,13 +1,13 @@
-#!c:\\python\\python.exe
 import getopt
 import os
 import sys
 import threading
 import time
 from io import open
-
 import impacket
 import impacket.ImpactDecoder
+
+import netifaces as ni
 
 # noinspection PyUnresolvedReferences
 import pcapy  # pytype: disable=import-error
@@ -74,6 +74,12 @@ Network Device List:
                 except Exception:
                     ip = winreg.QueryValueEx(key, "IPAddress")[0][0]
 
+                pcapy_device = pcapy_device + "\t" + ip
+            except Exception:
+                pass
+        elif sys.platform.startswith("lin"):
+            try:
+                ip = ni.ifaddresses(pcapy_device)[ni.AF_INET][0]["addr"]
                 pcapy_device = pcapy_device + "\t" + ip
             except Exception:
                 pass


### PR DESCRIPTION
Problem:
- `NetworkMonitorPedrpcServer` does not wait for `PcapThread` packet handling to end.
- `data_bytes` is incorrect because post_send is triggered before packet handling ends.
- Sometimes `data_bytes` could even be 0, resulting in boofuzz detecting a crash (see `sessions.py` line 937).

https://github.com/jtpereyda/boofuzz/blob/0c03ee04817fae24b0f42f4dedcb09bff00def96/boofuzz/sessions.py#L936-L937

Fix:
- `NetworkMonitorPedrpcServer` now waits for `PcapThread` packet handling to end.
- `data_bytes` is now correct

Note: Also added Linux support

See #468 for context