### PR TITLE
Add stub for set_crash_filename in NetworkMonitorPedrpcServer

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,12 +15,12 @@ Features
 - Independent mutation and encoding steps: Will enable multiple mutations and code coverage feedback.
 - Procmon: Additional debug steps. Partial backwards compatibility for old interface.
 
-
 Fixes
 ^^^^^
 - Various web interface fixes.
 - Various refactors and simplifications.
 - Fewer duplicates from `Group` primitives.
+- Fixed a crash when using the network monitor
 
 v0.2.1
 ------

--- a/network_monitor.py
+++ b/network_monitor.py
@@ -244,6 +244,10 @@ class NetworkMonitorPedrpcServer(pedrpc.Server):
         self.log("updating log path to '%s'" % new_log_path)
         self.log_path = new_log_path
 
+    def set_crash_filename(self, new_crash_filename):
+        """Stub to prevent a crash when this function is called on all monitors in session.py"""
+        return
+
 
 def main():
     ifs = get_ifs()


### PR DESCRIPTION
Implementing the fix discussed in https://github.com/jtpereyda/boofuzz/issues/468#issuecomment-705680087

@Eki474 does this fix the first bug described in #468?