### PR TITLE
Ignore twitter in sphinx linkcheck

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -78,9 +78,7 @@ pygments_style = "stata-dark"
 todo_include_todos = False
 
 linkcheck_ignore = [
-    # Requires a more liberal 'Accept: ' HTTP request header:
-    # Ref: https://github.com/sphinx-doc/sphinx/issues/7247
-    r"https://github\.com/jtpereyda/boofuzz/workflows/[^/]+/badge\.svg",
+    r"https://twitter.com/b00fuzz",
 ]
 
 


### PR DESCRIPTION
In #402 we added an exclude for the GitHub Action badge in the Sphinx linkcheck.

This seems to be fixed, but now the Twitter link makes problems. Hence the ignore.