### PR TITLE
Local procmon

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -24,6 +24,7 @@ Fixes
 - Fewer duplicates from `Group` primitives.
 - Network monitor: fixed data_bytes calculation and PcapThread synchronization
 - Fixed a crash when using the network monitor
+- Session can now be "quiet" by passing an empty list of loggers
 
 v0.2.1
 ------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,7 @@ Features
 - Protocol definition: Protocols can now be defined with an object oriented rather than static approach.
 - Independent mutation and encoding steps: Will enable multiple mutations and code coverage feedback.
 - Procmon: Additional debug steps. Partial backwards compatibility for old interface.
+- `ProcessMonitorLocal` allows running procmon as part of fuzzer process.
 - Network monitor: improved network interface discovery (Linux support)
 - Add support for fuzzing Unix sockets with the `UnixSocketConnection` class.
 

--- a/boofuzz/__init__.py
+++ b/boofuzz/__init__.py
@@ -109,6 +109,7 @@ __all__ = [
     "pedrpc",
     "primitives",
     "ProcessMonitor",
+    "ProcessMonitorLocal",
     "QWord",
     "RandomData",
     "RawL2SocketConnection",

--- a/boofuzz/__init__.py
+++ b/boofuzz/__init__.py
@@ -36,6 +36,7 @@ from .fuzzable_block import FuzzableBlock
 from .ifuzz_logger import IFuzzLogger
 from .ifuzz_logger_backend import IFuzzLoggerBackend
 from .monitors import BaseMonitor, CallbackMonitor, NetworkMonitor, pedrpc, ProcessMonitor
+from .utils.process_monitor_local import ProcessMonitorLocal
 from .primitives import (
     BasePrimitive,
     BitField,

--- a/boofuzz/sessions.py
+++ b/boofuzz/sessions.py
@@ -467,11 +467,11 @@ class Session(pgraph.Graph):
         self.restart_timeout = restart_timeout
         if fuzz_loggers is None:
             fuzz_loggers = []
-        if self.console_gui and os.name != "nt":
-            fuzz_loggers.append(fuzz_logger_curses.FuzzLoggerCurses(web_port=self.web_port))
-            self._keep_web_open = False
-        if len(fuzz_loggers) == 0:
-            fuzz_loggers = [fuzz_logger_text.FuzzLoggerText()]
+            if self.console_gui and os.name != "nt":
+                fuzz_loggers.append(fuzz_logger_curses.FuzzLoggerCurses(web_port=self.web_port))
+                self._keep_web_open = False
+            else:
+                fuzz_loggers = [fuzz_logger_text.FuzzLoggerText()]
 
         helpers.mkdir_safe(os.path.join(constants.RESULTS_DIR))
         self._run_id = datetime.datetime.utcnow().replace(microsecond=0).isoformat().replace(":", "-")

--- a/boofuzz/utils/debugger_thread_simple.py
+++ b/boofuzz/utils/debugger_thread_simple.py
@@ -212,7 +212,9 @@ class DebuggerThreadSimple(threading.Thread):
         try:
             os.kill(self.pid, signal.SIGKILL)
         except OSError as e:
-            print("Error while killing process. PID: {0} errno: {1} \"{2}\"".format(self.pid, e.errno, os.strerror(e.errno)))
+            print(
+                'Error while killing process. PID: {0} errno: {1} "{2}"'.format(self.pid, e.errno, os.strerror(e.errno))
+            )
             raise e
 
     def pre_send(self):

--- a/boofuzz/utils/debugger_thread_simple.py
+++ b/boofuzz/utils/debugger_thread_simple.py
@@ -212,7 +212,8 @@ class DebuggerThreadSimple(threading.Thread):
         try:
             os.kill(self.pid, signal.SIGKILL)
         except OSError as e:
-            print(e.errno)  # TODO interpret some basic errors
+            print("Error while killing process. PID: {0} errno: {1} \"{2}\"".format(self.pid, e.errno, os.strerror(e.errno)))
+            raise e
 
     def pre_send(self):
         pass

--- a/boofuzz/utils/process_monitor_local.py
+++ b/boofuzz/utils/process_monitor_local.py
@@ -8,7 +8,7 @@ from builtins import str
 
 from past.builtins import map
 
-from boofuzz import pedrpc, utils
+from boofuzz import utils
 from boofuzz.monitors.base_monitor import BaseMonitor
 
 

--- a/boofuzz/utils/process_monitor_local.py
+++ b/boofuzz/utils/process_monitor_local.py
@@ -1,0 +1,264 @@
+from __future__ import print_function
+
+import os
+import shlex
+import subprocess
+import time
+from builtins import str
+
+from past.builtins import map
+
+from boofuzz import pedrpc, utils
+from boofuzz.monitors.base_monitor import BaseMonitor
+
+
+def _split_command_if_str(command):
+    """Splits a shell command string into a list of arguments.
+
+    If any individual item is not a string, item is returned unchanged.
+
+    Designed for use with subprocess.Popen.
+
+    Args:
+        command (Union[basestring, :obj:`list` of :obj:`basestring`]): List of commands. Each command
+        should be a string or a list of strings.
+
+    Returns:
+        (:obj:`list` of :obj:`list`: of :obj:`str`): List of lists of command arguments.
+    """
+    if isinstance(command, str):
+        return shlex.split(command, posix=(os.name == "posix"))
+
+    else:
+        return command
+
+
+class ProcessMonitorLocal(BaseMonitor):
+    def __init__(
+        self, crash_filename, debugger_class, proc_name=None, pid_to_ignore=None, level=1, coredump_dir=None
+    ):
+        """
+        @type  crash_filename: str
+        @param crash_filename: Name of file to (un)serialize crash bin to/from
+        @type  proc_name:      str
+        @param proc_name:      (Optional, def=None) Process name to search for and attach to
+        @type  pid_to_ignore:  int
+        @param pid_to_ignore:  (Optional, def=None) Ignore this PID when searching for the target process
+        @type  level:          int
+        @param level:          (Optional, def=1) Log output level, increase for more verbosity
+        """
+
+        self.crash_filename = os.path.abspath(crash_filename)
+        self.debugger_class = debugger_class
+        self.proc_name = proc_name
+        self.ignore_pid = pid_to_ignore
+        self.log_level = level
+        self.capture_output = False
+
+        self.stop_commands = []
+        self.start_commands = []
+        self.test_number = None
+        self.debugger_thread = None
+        self.crash_bin = utils.crash_binning.CrashBinning()
+
+        self.last_synopsis = ""
+
+        self.coredump_dir = coredump_dir
+
+        if not os.access(os.path.dirname(self.crash_filename), os.X_OK):
+            self.log("invalid path specified for crash bin: %s" % self.crash_filename)
+            raise Exception
+
+        self.log("Process Monitor PED-RPC server initialized:")
+        # self.log("\t listening on:  %s:%s" % (host, port))
+        self.log("\t crash file:    %s" % self.crash_filename)
+        self.log("\t # records:     %d" % len(self.crash_bin.bins))
+        self.log("\t proc name:     %s" % self.proc_name)
+        self.log("\t log level:     %d" % self.log_level)
+        self.log("awaiting requests...")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        if self.debugger_thread is not None and self.debugger_thread.isAlive():
+            self.debugger_thread.stop_target()
+        self.stop()
+
+    # noinspection PyMethodMayBeStatic
+    def alive(self):
+        """
+        Returns True. Useful for PED-RPC clients who want to see if the PED-RPC connection is still alive.
+        """
+
+        return True
+
+    def get_crash_synopsis(self):
+        """
+        Return the last recorded crash synopsis.
+
+        @rtype:  String
+        @return: Synopsis of last recorded crash.
+        """
+        # Since crash synopsis is called only after a failure, check for failures again:
+        self.debugger_thread.post_send()
+
+        return self.last_synopsis
+
+    def log(self, msg="", level=1):
+        """
+        If the supplied message falls under the current log level, print the specified message to screen.
+
+        @type  msg: str
+        @param msg: Message to log
+        """
+
+        if self.log_level >= level:
+            print("[%s] %s" % (time.strftime("%I:%M.%S"), msg))
+
+    def post_send(self, **kwargs):
+        """
+        This routine is called after the fuzzer transmits a test case and returns the status of the target.
+
+        Returns:
+            bool: True if the target is still active, False otherwise.
+        """
+        # note: kwargs for pedrpc client compatibility
+        if self.debugger_thread is not None:
+            return self.debugger_thread.post_send()
+        else:
+            raise Exception("post_send called before pre_send!")
+
+    def pre_send(self, *args, **kwargs):
+        """
+        This routine is called before the fuzzer transmits a test case and ensure the debugger thread is operational.
+
+        @type  test_number: Integer
+        @param test_number: Test number to retrieve PCAP for.
+        """
+        if len(args) > 0:
+            test_number = args[0]
+        else:
+            session = kwargs["session"]
+            test_number = session.total_mutant_index
+        # note: kwargs for pedrpc client compatibility
+        self.log("pre_send(%d)" % test_number, 10)
+        self.test_number = test_number
+
+        if self.debugger_thread is None or not self.debugger_thread.isAlive():
+            self.start_target()
+            self.debugger_thread.pre_send()
+
+    def start_target(self):
+        """
+        Start up the target process by issuing the commands in self.start_commands.
+
+        @returns True if successful.
+        """
+        self.log("local Starting target...")
+        self._stop_target_if_running()
+        self.log("creating debugger thread", 5)
+        self.debugger_thread = self.debugger_class(
+            self.start_commands,
+            self,
+            proc_name=self.proc_name,
+            ignore_pid=self.ignore_pid,
+            log_level=self.log_level,
+            coredump_dir=self.coredump_dir,
+            capture_output=self.capture_output,
+        )
+        self.debugger_thread.daemon = True
+        self.debugger_thread.start()
+        self.debugger_thread.finished_starting.wait()
+        self.log("giving debugger thread 2 seconds to settle in", 5)
+        time.sleep(2)
+        return True
+
+    def stop_target(self):
+        """
+        Kill the current debugger thread and stop the target process by issuing the commands in self.stop_commands.
+        """
+        self.log("Stopping target...")
+
+        if self._target_is_running():
+            self._stop_target()
+            self.log("target stopped")
+        else:
+            self.log("target already stopped")
+
+    def _stop_target_if_running(self):
+        """Stop target, if it is running. Return true if it was running; otherwise false."""
+        if self._target_is_running():
+            self.log("target still running; stopping first...")
+            self._stop_target()
+            self.log("target stopped")
+            return True
+        else:
+            return False
+
+    def _stop_target(self):
+        # give the debugger thread a chance to exit.
+        time.sleep(1)
+        if len(self.stop_commands) < 1:
+            self.debugger_thread.stop_target()
+            while self.debugger_thread.isAlive():
+                time.sleep(0.1)
+        else:
+            for command in self.stop_commands:
+                if command == ["TERMINATE_PID"] or command == "TERMINATE_PID":
+                    self.debugger_thread.stop_target()
+                    while self.debugger_thread.isAlive():
+                        time.sleep(0.1)
+                else:
+                    self.log("Executing stop command: '{0}'".format(command), 2)
+                    subprocess.Popen(command)
+
+    def _target_is_running(self):
+        return self.debugger_thread is not None and self.debugger_thread.isAlive()
+
+    def restart_target(self, **kwargs):
+        """
+        Stop and start the target process.
+
+        @returns True if successful.
+        """
+        # note: kwargs for pedrpc client compatibility
+        self.log("Restarting target...")
+        self.stop_target()
+        return self.start_target()
+
+    def set_capture_output(self, capture_output):
+        self.log("updating capture_output to '%s'" % capture_output)
+        self.capture_output = capture_output
+
+    def set_proc_name(self, new_proc_name):
+        self.log("updating target process name to '%s'" % new_proc_name)
+        self.proc_name = new_proc_name
+
+    def set_start_commands(self, new_start_commands):
+        self.log("updating start commands to: {0}".format(list(new_start_commands)))
+        self.start_commands = map(_split_command_if_str, new_start_commands)
+
+    def set_stop_commands(self, new_stop_commands):
+        self.log("updating stop commands to: {0}".format(list(new_stop_commands)))
+        self.stop_commands = new_stop_commands
+        self.stop_commands = map(_split_command_if_str, new_stop_commands)
+
+    def set_crash_filename(self, new_crash_filename):
+        self.log("updating crash bin filename to '%s'" % new_crash_filename)
+        self.crash_filename = new_crash_filename
+
+    def set_options(self, *args, **kwargs):
+        """
+        Compatibility method to act like a pedrpc client.
+        """
+        # args will be ignored, kwargs will be translated
+
+        for arg, value in kwargs.items():
+            setattr(self, arg, value)
+
+    def post_start_target(self, *args, **kwargs):
+        """
+        Compatibility method to act like a pedrpc client.
+        """
+        return

--- a/boofuzz/utils/process_monitor_local.py
+++ b/boofuzz/utils/process_monitor_local.py
@@ -81,7 +81,6 @@ class ProcessMonitorLocal(BaseMonitor):
     def __exit__(self, exc_type, exc_value, traceback):
         if self.debugger_thread is not None and self.debugger_thread.isAlive():
             self.debugger_thread.stop_target()
-        self.stop()
 
     # noinspection PyMethodMayBeStatic
     def alive(self):

--- a/boofuzz/utils/process_monitor_local.py
+++ b/boofuzz/utils/process_monitor_local.py
@@ -34,9 +34,7 @@ def _split_command_if_str(command):
 
 
 class ProcessMonitorLocal(BaseMonitor):
-    def __init__(
-        self, crash_filename, debugger_class, proc_name=None, pid_to_ignore=None, level=1, coredump_dir=None
-    ):
+    def __init__(self, crash_filename, debugger_class, proc_name=None, pid_to_ignore=None, level=1, coredump_dir=None):
         """
         @type  crash_filename: str
         @param crash_filename: Name of file to (un)serialize crash bin to/from


### PR DESCRIPTION
Local process monitor so as to run targets without a separate procmon command.

The implementation suggests some refactors:

1. Use local procmon as the main procmon implementation. Rewrite the ProcessMonitorPedrpcServer to just have-a ProcessMonitorLocal.
2. Clarify the differences between the server and client side process monitors. I think the method args can be identical -- right now they're mostly identical with subtle differences.
3. Have the local procmon, the client procmon, and the server procmon all inherit from the procmon base class.

However it might be best to merge as is for the purposes of moving forward.

Also slipped in a change for loggers: If you pass no loggers, the Session still creates a default for you. If you pass an empty list however, you're saying you want no loggers, and the console output will be quiet.