### PR TITLE
Protocol Session Metadata

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ Features
 - `ProcessMonitorLocal` allows running procmon as part of fuzzer process.
 - Network monitor: improved network interface discovery (Linux support)
 - Add support for fuzzing Unix sockets with the `UnixSocketConnection` class.
+- Add metadata to ProtocolSession to support callbacks -- `current_message`, `previous_message`.
 
 Fixes
 ^^^^^

--- a/boofuzz/fuzzable.py
+++ b/boofuzz/fuzzable.py
@@ -159,11 +159,11 @@ class Fuzzable(object):
         if self.qualified_name in mutation_context.mutation.mutations:
             mutation = mutation_context.mutation.mutations[self.qualified_name]
             if callable(mutation):
-                value = mutation(self.original_value(test_case_context=mutation_context.test_case_context))
+                value = mutation(self.original_value(test_case_context=mutation_context.protocol_session))
             else:
                 value = mutation
         else:
-            value = self.original_value(test_case_context=mutation_context.test_case_context)
+            value = self.original_value(test_case_context=mutation_context.protocol_session)
 
         return value
 

--- a/boofuzz/mutation.py
+++ b/boofuzz/mutation.py
@@ -4,4 +4,4 @@ import attr
 @attr.s
 class Mutation(object):
     mutations = attr.ib(factory=dict)
-    message_path = attr.ib(default="")
+    message_path = attr.ib(factory=list)

--- a/boofuzz/mutation_context.py
+++ b/boofuzz/mutation_context.py
@@ -19,4 +19,4 @@ class MutationContext(object):
     """
 
     mutation = attr.ib(type=Mutation)
-    test_case_context = attr.ib(type=ProtocolSession, default=None)
+    protocol_session = attr.ib(type=ProtocolSession, default=None)

--- a/boofuzz/protocol_session.py
+++ b/boofuzz/protocol_session.py
@@ -11,3 +11,5 @@ class ProtocolSession(object):
     """
 
     session_variables = attr.ib(factory=dict)
+    previous_message = attr.ib(default=None)
+    current_message = attr.ib(default=None)

--- a/boofuzz/sessions.py
+++ b/boofuzz/sessions.py
@@ -1193,7 +1193,7 @@ class Session(pgraph.Graph):
 
         # if the edge has a callback, process it. the callback has the option to render the node, modify it and return.
         if edge.callback:
-            self._fuzz_data_logger.open_test_step("Callback function")
+            self._fuzz_data_logger.open_test_step("Callback function '{0}'".format(edge.callback.__name__))
             data = edge.callback(
                 self.targets[0],
                 self._fuzz_data_logger,

--- a/boofuzz/sessions.py
+++ b/boofuzz/sessions.py
@@ -1088,9 +1088,9 @@ class Session(pgraph.Graph):
             session (Session): Session object calling post_send.
                 Useful properties include last_send and last_recv.
             test_case_context (ProtocolSession): Context for test case-scoped data.
-                :py:class:`TestCaseContext` :py:attr:`session_variables <TestCaseContext.session_variables>`
+                :py:class:`ProtocolSession` :py:attr:`session_variables <ProtocolSession.session_variables>`
                 values are generally set within a callback and referenced in elements via default values of type
-                :py:class:`ReferenceValueTestCaseSession`.
+                :py:class:`ProtocolSessionReference`.
             args: Implementations should include \\*args and \\**kwargs for forward-compatibility.
             kwargs: Implementations should include \\*args and \\**kwargs for forward-compatibility.
         """
@@ -1482,19 +1482,19 @@ class Session(pgraph.Graph):
 
         try:
             self._open_connection_keep_trying(target)
-            test_case_context = ProtocolSession()
-            mutation_context.test_case_context = test_case_context
+            protocol_session = ProtocolSession()
+            mutation_context.protocol_session = protocol_session
 
             self._pre_send(target)
 
             for e in mutation.message_path[:-1]:
                 node = self.nodes[e.dst]
                 self._fuzz_data_logger.open_test_step("Prep Node '{0}'".format(node.name))
-                callback_data = self._callback_current_node(node=node, edge=e, test_case_context=test_case_context)
+                callback_data = self._callback_current_node(node=node, edge=e, test_case_context=protocol_session)
                 self.transmit_normal(target, node, e, callback_data=callback_data, mutation_context=mutation_context)
 
             callback_data = self._callback_current_node(
-                node=self.fuzz_node, edge=mutation.message_path[-1], test_case_context=test_case_context
+                node=self.fuzz_node, edge=mutation.message_path[-1], test_case_context=protocol_session
             )
 
             self._fuzz_data_logger.open_test_step("Node Under Test '{0}'".format(self.fuzz_node.name))
@@ -1565,7 +1565,7 @@ class Session(pgraph.Graph):
         try:
             self._open_connection_keep_trying(target)
             test_case_context = ProtocolSession()
-            mutation_context.test_case_context = test_case_context
+            mutation_context.protocol_session = test_case_context
 
             self._pre_send(target)
 

--- a/boofuzz/sessions.py
+++ b/boofuzz/sessions.py
@@ -1482,17 +1482,27 @@ class Session(pgraph.Graph):
 
         try:
             self._open_connection_keep_trying(target)
-            protocol_session = ProtocolSession()
-            mutation_context.protocol_session = protocol_session
-
             self._pre_send(target)
 
             for e in mutation.message_path[:-1]:
+                prev_node = self.nodes[e.src]
                 node = self.nodes[e.dst]
+                protocol_session = ProtocolSession(
+                    previous_message=prev_node,
+                    current_message=node,
+                )
+                mutation_context.protocol_session = protocol_session
                 self._fuzz_data_logger.open_test_step("Prep Node '{0}'".format(node.name))
                 callback_data = self._callback_current_node(node=node, edge=e, test_case_context=protocol_session)
                 self.transmit_normal(target, node, e, callback_data=callback_data, mutation_context=mutation_context)
 
+            prev_node = self.nodes[mutation.message_path[-1].src]
+            node = self.nodes[mutation.message_path[-1].dst]
+            protocol_session = ProtocolSession(
+                previous_message=prev_node,
+                current_message=node,
+            )
+            mutation_context.protocol_session = protocol_session
             callback_data = self._callback_current_node(
                 node=self.fuzz_node, edge=mutation.message_path[-1], test_case_context=protocol_session
             )
@@ -1564,19 +1574,30 @@ class Session(pgraph.Graph):
 
         try:
             self._open_connection_keep_trying(target)
-            test_case_context = ProtocolSession()
-            mutation_context.protocol_session = test_case_context
 
             self._pre_send(target)
 
             for e in mutation.message_path[:-1]:
+                prev_node = self.nodes[e.src]
                 node = self.nodes[e.dst]
-                callback_data = self._callback_current_node(node=node, edge=e, test_case_context=test_case_context)
+                protocol_session = ProtocolSession(
+                    previous_message=prev_node,
+                    current_message=node,
+                )
+                mutation_context.protocol_session = protocol_session
+                callback_data = self._callback_current_node(node=node, edge=e, test_case_context=protocol_session)
                 self._fuzz_data_logger.open_test_step("Transmit Prep Node '{0}'".format(node.name))
                 self.transmit_normal(target, node, e, callback_data=callback_data, mutation_context=mutation_context)
 
+            prev_node = self.nodes[mutation.message_path[-1].src]
+            node = self.nodes[mutation.message_path[-1].dst]
+            protocol_session = ProtocolSession(
+                previous_message=prev_node,
+                current_message=node,
+            )
+            mutation_context.protocol_session = protocol_session
             callback_data = self._callback_current_node(
-                node=self.fuzz_node, edge=mutation.message_path[-1], test_case_context=test_case_context
+                node=self.fuzz_node, edge=mutation.message_path[-1], test_case_context=protocol_session
             )
             self._fuzz_data_logger.open_test_step("Fuzzing Node '{0}'".format(self.fuzz_node.name))
             self.transmit_fuzz(


### PR DESCRIPTION
Added references to the "current" and "previous" message in message-specific (rather, transition-specific) callbacks. The interface is somewhat experimental still. See https://github.com/jtpereyda/boofuzz-ftp/pull/3 for usage example.