### PR TITLE
Update block and primitive documentation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,7 @@ Features
 - Network monitor: improved network interface discovery (Linux support)
 - Add support for fuzzing Unix sockets with the `UnixSocketConnection` class.
 - Add metadata to ProtocolSession to support callbacks -- `current_message`, `previous_message`.
+- All primitive arguments are now optional keyword arguments.
 
 Fixes
 ^^^^^

--- a/boofuzz/__init__.py
+++ b/boofuzz/__init__.py
@@ -667,7 +667,7 @@ def s_random(value, min_length, max_length, num_mutations=25, fuzzable=True, ste
             default_value=value,
             min_length=min_length,
             max_length=max_length,
-            num_mutations=num_mutations,
+            max_mutations=num_mutations,
             step=step,
             fuzzable=fuzzable,
         )

--- a/boofuzz/__init__.py
+++ b/boofuzz/__init__.py
@@ -253,7 +253,7 @@ def s_switch(name):
 # ## BLOCK MANAGEMENT
 
 
-def s_block(name, group=None, encoder=None, dep=None, dep_value=None, dep_values=(), dep_compare="=="):
+def s_block(name=None, group=None, encoder=None, dep=None, dep_value=None, dep_values=None, dep_compare="=="):
     """
     Open a new block under the current request. The returned instance supports the "with" interface so it will
     be automatically closed for you::
@@ -263,19 +263,19 @@ def s_block(name, group=None, encoder=None, dep=None, dep_value=None, dep_values
             if s_block_start("body"):
                 ...
 
-    :type  name:        str
+    :type  name:        str, optional
     :param name:        Name of block being opened
-    :type  group:       str
+    :type  group:       str, optional
     :param group:       (Optional, def=None) Name of group to associate this block with
-    :type  encoder:     Function Pointer
+    :type  encoder:     Function Pointer, optional
     :param encoder:     (Optional, def=None) Optional pointer to a function to pass rendered data to prior to return
-    :type  dep:         str
+    :type  dep:         str, optional
     :param dep:         (Optional, def=None) Optional primitive whose specific value this block is dependant on
-    :type  dep_value:   Mixed
+    :type  dep_value:   Mixed, optional
     :param dep_value:   (Optional, def=None) Value that field "dep" must contain for block to be rendered
-    :type  dep_values:  List of Mixed Types
-    :param dep_values:  (Optional, def=[]) Values that field "dep" may contain for block to be rendered
-    :type  dep_compare: str
+    :type  dep_values:  List of Mixed Types, optional
+    :param dep_values:  (Optional, def=None) Values that field "dep" may contain for block to be rendered
+    :type  dep_compare: str, optional
     :param dep_compare: (Optional, def="==") Comparison method to use on dependency (==, !=, >, >=, <, <=)
     """
 
@@ -310,12 +310,12 @@ def s_block(name, group=None, encoder=None, dep=None, dep_value=None, dep_values
     return ScopedBlock(block)
 
 
-def s_aligned(modulus, pattern=b"\x00", name=None):
+def s_aligned(modulus=1, pattern=b"\x00", name=None):
     """FuzzableBlock that aligns its contents to a certain number of bytes
 
-    :type  modulus:     int
-    :param modulus:     Pad length of child content to this many bytes
-    :type  pattern:     bytes
+    :type  modulus:     int, optional
+    :param modulus:     Pad length of child content to this many bytes, defaults to 1
+    :type  pattern:     bytes, optional
     :param pattern:     Pad using these byte(s)
     :type  name:        str, optional
     :param name:        Name, for referencing later. Names should always be provided, but if not, a default name will
@@ -344,7 +344,7 @@ def s_aligned(modulus, pattern=b"\x00", name=None):
     return ScopedAligned(aligned)
 
 
-def s_block_start(name, *args, **kwargs):
+def s_block_start(name=None, *args, **kwargs):
     """
     Open a new block under the current request. This routine always returns an instance so you can make your fuzzer
     pretty with indenting::
@@ -376,7 +376,7 @@ def s_block_end(name=None):
 
 
 def s_checksum(
-    block_name,
+    block_name=None,
     algorithm="crc32",
     length=0,
     endian=LITTLE_ENDIAN,
@@ -396,7 +396,7 @@ def s_checksum(
     Recursive checksums are supported; the checksum field itself will render as all zeros for the sake of checksum
     or length calculations.
 
-    :type  block_name: str
+    :type  block_name: str, optional
     :param block_name: Name of target block for checksum calculations.
     :type  algorithm: str, function, optional
     :param algorithm: Checksum algorithm to use. (crc32, crc32c, adler32, md5, sha1, ipv4, udp)
@@ -407,9 +407,9 @@ def s_checksum(
         algorithm, defaults to 0
     :type  endian: chr, optional
     :param endian: Endianness of the bit field (LITTLE_ENDIAN: <, BIG_ENDIAN: >), defaults to LITTLE_ENDIAN
-    :type  fuzzable:   bool
-    :param fuzzable:   (Optional, def=True) Enable/disable fuzzing.
-    :type  name: str
+    :type  fuzzable:   bool, optional
+    :param fuzzable:   Enable/disable fuzzing.
+    :type  name: str, optional
     :param name: Name, for referencing later. Names should always be provided, but if not, a default name will be given,
         defaults to None
     :type  ipv4_src_block_name: str, optional
@@ -438,7 +438,7 @@ def s_checksum(
     blocks.CURRENT.push(checksum)
 
 
-def s_repeat(block_name, min_reps=0, max_reps=None, step=1, variable=None, fuzzable=True, name=None):
+def s_repeat(block_name=None, min_reps=0, max_reps=25, step=1, variable=None, fuzzable=True, name=None):
     """
     Repeat the rendered contents of the specified block cycling from min_reps to max_reps counting by step. By
     default renders to nothing. This block modifier is useful for fuzzing overflows in table entries. This block
@@ -447,11 +447,11 @@ def s_repeat(block_name, min_reps=0, max_reps=None, step=1, variable=None, fuzza
     :see: Aliases: s_repeater()
 
     :type  block_name: str
-    :param block_name: Name of block to repeat
+    :param block_name: (Optional, def=None) Name of block to repeat
     :type  min_reps:   int
     :param min_reps:   (Optional, def=0) Minimum number of block repetitions
     :type  max_reps:   int
-    :param max_reps:   (Optional, def=None) Maximum number of block repetitions
+    :param max_reps:   (Optional, def=25) Maximum number of block repetitions
     :type  step:       int
     :param step:       (Optional, def=1) Step count between min and max reps
     :type  variable:   Sulley Integer Primitive
@@ -477,7 +477,7 @@ def s_repeat(block_name, min_reps=0, max_reps=None, step=1, variable=None, fuzza
 
 
 def s_size(
-    block_name,
+    block_name=None,
     offset=0,
     length=4,
     endian=LITTLE_ENDIAN,
@@ -494,7 +494,7 @@ def s_size(
 
     :see: Aliases: s_sizer()
 
-    :type  block_name:    str
+    :type  block_name:    str, optional
     :param block_name:    Name of block to apply sizer to.
     :type  offset:        int, optional
     :param offset:        Offset for calculated size value, defaults to 0
@@ -582,12 +582,12 @@ def s_binary(value, name=None):
     blocks.CURRENT.push(Static(name=name, default_value=parsed, fuzzable=False))
 
 
-def s_delim(value, fuzzable=True, name=None):
+def s_delim(value=" ", fuzzable=True, name=None):
     """
     Push a delimiter onto the current block stack.
 
     :type  value:    Character
-    :param value:    Original value
+    :param value:    (Optional, def=" ")Original value
     :type  fuzzable: bool
     :param fuzzable: (Optional, def=True) Enable/disable fuzzing of this primitive
     :type  name:     str
@@ -597,17 +597,17 @@ def s_delim(value, fuzzable=True, name=None):
     blocks.CURRENT.push(Delim(name=name, default_value=value, fuzzable=fuzzable))
 
 
-def s_group(name, values, default_value=None):
+def s_group(name=None, values=None, default_value=None):
     """
     This primitive represents a list of static values, stepping through each one on mutation. You can tie a block
     to a group primitive to specify that the block should cycle through all possible mutations for *each* value
     within the group. The group primitive is useful for example for representing a list of valid opcodes.
 
     :type  name:            str
-    :param name:            Name of group
+    :param name:            (Optional, def=None) Name of group
     :type  values:          List or raw data
-    :param values:          List of possible raw values this group can take.
-
+    :param values:          (Optional, def=None) List of possible raw values this group can take.
+    :type  default_value:   str or bytes
     :param default_value:   (Optional, def=None) Specifying a value when fuzzing() is complete
     """
 
@@ -640,17 +640,17 @@ def s_lego(lego_type, value=None, options=()):
     blocks.CURRENT.pop()
 
 
-def s_random(value, min_length, max_length, num_mutations=25, fuzzable=True, step=None, name=None):
+def s_random(value="", min_length=0, max_length=1, num_mutations=25, fuzzable=True, step=None, name=None):
     """
     Generate a random chunk of data while maintaining a copy of the original. A random length range can be specified.
     For a static length, set min/max length to be the same.
 
     :type  value:         Raw
-    :param value:         Original value
+    :param value:         (Optional, def="") Original value
     :type  min_length:    int
-    :param min_length:    Minimum length of random block
+    :param min_length:    (Optional, def=0) Minimum length of random block
     :type  max_length:    int
-    :param max_length:    Maximum length of random block
+    :param max_length:    (Optional, def=1) Maximum length of random block
     :type  num_mutations: int
     :param num_mutations: (Optional, def=25) Number of mutations to make before reverting to default
     :type  fuzzable:      bool
@@ -674,7 +674,7 @@ def s_random(value, min_length, max_length, num_mutations=25, fuzzable=True, ste
     )
 
 
-def s_static(value, name=None):
+def s_static(value=None, name=None):
     """
     Push a static value onto the current block stack.
 
@@ -689,24 +689,24 @@ def s_static(value, name=None):
     blocks.CURRENT.push(Static(name=name, default_value=value))
 
 
-def s_mirror(primitive_name, name=None):
+def s_mirror(primitive_name=None, name=None):
     """
     Push a mirror of another primitive onto the current block stack.
 
     :type primitive_name:   str
-    :param primitive_name:  Name of target primitive
+    :param primitive_name:  (Optional, def=None) Name of target primitive
     :type name:             str
     :param name:            (Optional, def=None) Name of current primitive
     """
     blocks.CURRENT.push(Mirror(name=name, primitive_name=primitive_name, request=blocks.CURRENT))
 
 
-def s_string(value, size=-1, padding=b"\x00", encoding="ascii", fuzzable=True, max_len=0, name=None):
+def s_string(value="", size=-1, padding=b"\x00", encoding="ascii", fuzzable=True, max_len=0, name=None):
     """
     Push a string onto the current block stack.
 
     :type  value:    str
-    :param value:    Default string value
+    :param value:    (Optional, def="")Default string value
     :type  size:     int
     :param size:     (Optional, def=-1) Static size of this field, leave -1 for dynamic.
     :type  padding:  Character
@@ -734,14 +734,14 @@ def s_string(value, size=-1, padding=b"\x00", encoding="ascii", fuzzable=True, m
     )
 
 
-def s_from_file(value, filename, encoding="ascii", fuzzable=True, max_len=0, name=None):
+def s_from_file(value="", filename=None, encoding="ascii", fuzzable=True, max_len=0, name=None):
     """
     Push a value from file onto the current block stack.
 
     :type  value:    str
-    :param value:    Default string value
+    :param value:    (Optional, def="") Default string value
     :type  filename: str
-    :param filename: Filename pattern to load all fuzz value
+    :param filename: (Optional, def=None) Filename pattern to load all fuzz value
     :type  encoding: str
     :param encoding: (DEPRECIATED, def="ascii") String encoding, ex: utf_16_le for Microsoft Unicode.
     :type  fuzzable: bool
@@ -757,8 +757,8 @@ def s_from_file(value, filename, encoding="ascii", fuzzable=True, max_len=0, nam
 
 # noinspection PyTypeChecker
 def s_bit_field(
-    value,
-    width,
+    value=0,
+    width=8,
     endian=LITTLE_ENDIAN,
     output_format="binary",
     signed=False,
@@ -773,11 +773,11 @@ def s_bit_field(
     :see: Aliases: s_bit(), s_bits()
 
     :type  value:          int
-    :param value:          Default integer value
+    :param value:          (Optional, def=0) Default integer value
     :type  width:          int
-    :param width:          Width of bit fields
+    :param width:          (Optional, def=8) Width of bit fields
     :type  endian:         Character
-    :param endian:         (Optional, def=LITTLE_ENDIAN) Endianess of the bit field (LITTLE_ENDIAN: <, BIG_ENDIAN: >)
+    :param endian:         (Optional, def=LITTLE_ENDIAN) Endianness of the bit field (LITTLE_ENDIAN: <, BIG_ENDIAN: >)
     :type  output_format:  str
     :param output_format:  (Optional, def=binary) Output format, "binary" or "ascii"
     :type  signed:         bool
@@ -808,7 +808,7 @@ def s_bit_field(
 
 
 def s_byte(
-    value,
+    value=0,
     endian=LITTLE_ENDIAN,
     output_format="binary",
     signed=False,
@@ -822,8 +822,8 @@ def s_byte(
 
     :see: Aliases: s_char()
 
-    :type  value:         int|str
-    :param value:         Default integer value
+    :type  value:         int|byte
+    :param value:         (Optional, def=0) Default integer value
     :type  endian:        Character
     :param endian:        (Optional, def=LITTLE_ENDIAN) Endianess of the bit field (LITTLE_ENDIAN: <, BIG_ENDIAN: >)
     :type  output_format: str
@@ -854,12 +854,12 @@ def s_byte(
     )
 
 
-def s_bytes(value, size=None, padding=b"\x00", fuzzable=True, max_len=None, name=None):
+def s_bytes(value=b"", size=None, padding=b"\x00", fuzzable=True, max_len=None, name=None):
     """
     Push a bytes field of arbitrary length onto the current block stack.
 
     :type  value:        bytes
-    :param value:        Default binary value
+    :param value:        (Optional, def=b"")Default binary value
     :type  size:         int
     :param size:         (Optional, def=None) Static size of this field, leave None for dynamic.
     :type  padding:      chr
@@ -878,7 +878,7 @@ def s_bytes(value, size=None, padding=b"\x00", fuzzable=True, max_len=None, name
 
 
 def s_word(
-    value,
+    value=0,
     endian=LITTLE_ENDIAN,
     output_format="binary",
     signed=False,
@@ -892,7 +892,7 @@ def s_word(
 
     :see: Aliases: s_short()
 
-    :type  value:         int
+    :type  value:         (Optional, def=0) int
     :param value:         Default integer value
     :type  endian:        chr
     :param endian:        (Optional, def=LITTLE_ENDIAN) Endianess of the bit field (LITTLE_ENDIAN: <, BIG_ENDIAN: >)
@@ -925,7 +925,7 @@ def s_word(
 
 
 def s_dword(
-    value,
+    value=0,
     endian=LITTLE_ENDIAN,
     output_format="binary",
     signed=False,
@@ -939,7 +939,7 @@ def s_dword(
 
     :see: Aliases: s_long(), s_int()
 
-    :type  value:         int
+    :type  value:         (Optional, def=0) int
     :param value:         Default integer value
     :type  endian:        Character
     :param endian:        (Optional, def=LITTLE_ENDIAN) Endianess of the bit field (LITTLE_ENDIAN: <, BIG_ENDIAN: >)
@@ -972,7 +972,7 @@ def s_dword(
 
 
 def s_qword(
-    value,
+    value=0,
     endian=LITTLE_ENDIAN,
     output_format="binary",
     signed=False,
@@ -986,7 +986,7 @@ def s_qword(
 
     :see: Aliases: s_double()
 
-    :type  value:         int
+    :type  value:         (Optional, def=0) int
     :param value:         Default integer value
     :type  endian:        Character
     :param endian:        (Optional, def=LITTLE_ENDIAN) Endianess of the bit field (LITTLE_ENDIAN: <, BIG_ENDIAN: >)

--- a/boofuzz/blocks/aligned.py
+++ b/boofuzz/blocks/aligned.py
@@ -4,18 +4,20 @@ from ..fuzzable_block import FuzzableBlock
 class Aligned(FuzzableBlock):
     """FuzzableBlock that aligns its contents to a certain number of bytes
 
-    :type  modulus:     int
-    :param modulus:     Pad length of child content to this many bytes
-    :type  request:     boofuzz.Request
-    :param request:     Request this block belongs to
-    :type  pattern:     bytes
-    :param pattern:     Pad using these byte(s)
     :type  name:        str, optional
     :param name:        Name, for referencing later. Names should always be provided, but if not, a default name will
                         be given, defaults to None
+    :type  modulus:     int, optional
+    :param modulus:     Pad length of child content to this many bytes, defaults to 1
+    :type  request:     boofuzz.Request, optional
+    :param request:     Request this block belongs to
+    :type  pattern:     bytes, optional
+    :param pattern:     Pad using these byte(s)
+    :type  fuzzable:    bool, optional
+    :param fuzzable:    Enable/disable fuzzing of this block, defaults to true
     """
 
-    def __init__(self, modulus, request=None, pattern=b"\x00", name=None, *args, **kwargs):
+    def __init__(self, name=None, modulus=1, request=None, pattern=b"\x00", *args, **kwargs):
         super(Aligned, self).__init__(name=name, default_value=None, request=request, *args, **kwargs)
         self._modulus = modulus
         self._pattern = pattern

--- a/boofuzz/blocks/aligned.py
+++ b/boofuzz/blocks/aligned.py
@@ -2,23 +2,20 @@ from ..fuzzable_block import FuzzableBlock
 
 
 class Aligned(FuzzableBlock):
-    """
-    This block type is kind of special in that it is a hybrid between a block and a primitive (it can be fuzzed). The
-    user does not need to be wary of this fact.
+    """FuzzableBlock that aligns its contents to a certain number of bytes
+
+    :type  modulus:     int
+    :param modulus:     Pad length of child content to this many bytes
+    :type  request:     boofuzz.Request
+    :param request:     Request this block belongs to
+    :type  pattern:     bytes
+    :param pattern:     Pad using these byte(s)
+    :type  name:        str, optional
+    :param name:        Name, for referencing later. Names should always be provided, but if not, a default name will
+                        be given, defaults to None
     """
 
-    def __init__(self, name, modulus, request=None, pattern=b"\x00", *args, **kwargs):
-        """
-        Create a sizer block bound to the block with the specified name. Size blocks that size their own parent or
-        grandparent are allowed.
-
-        :type  request:       Request
-        :param request:       Request this block belongs to
-        :type  modulus:     int
-        :param modulus:     Pad length of child content to this many bytes
-        :type  pattern:     bytes
-        :param pattern:     Pad using these byte(s)
-        """
+    def __init__(self, modulus, request=None, pattern=b"\x00", name=None, *args, **kwargs):
         super(Aligned, self).__init__(name=name, default_value=None, request=request, *args, **kwargs)
         self._modulus = modulus
         self._pattern = pattern

--- a/boofuzz/blocks/block.py
+++ b/boofuzz/blocks/block.py
@@ -9,7 +9,7 @@ class Block(FuzzableBlock):
     :param name: Name, for referencing later. Names should always be provided, but if not, a default name will be given,
         defaults to None
     :type name: str
-    :param default_value: Value used when the element is not being fuzzed – should typically represent a valid value,
+    :param default_value: Value used when the element is not being fuzzed - should typically represent a valid value,
         defaults to None
     :type default_value: Any, optional
     :param request: Request this block belongs to, defaults to None

--- a/boofuzz/blocks/block.py
+++ b/boofuzz/blocks/block.py
@@ -8,7 +8,7 @@ class Block(FuzzableBlock):
 
     :param name: Name, for referencing later. Names should always be provided, but if not, a default name will be given,
         defaults to None
-    :type name: str
+    :type name: str, optional
     :param default_value: Value used when the element is not being fuzzed - should typically represent a valid value,
         defaults to None
     :type default_value: Any, optional

--- a/boofuzz/blocks/block.py
+++ b/boofuzz/blocks/block.py
@@ -4,11 +4,38 @@ from ..fuzzable_block import FuzzableBlock
 
 
 class Block(FuzzableBlock):
+    """The basic building block. Can contain primitives, sizers, checksums or other blocks.
+
+    :param name: Name, for referencing later. Names should always be provided, but if not, a default name will be given,
+        defaults to None
+    :type name: str
+    :param default_value: Value used when the element is not being fuzzed – should typically represent a valid value,
+        defaults to None
+    :type default_value: Any, optional
+    :param request: Request this block belongs to, defaults to None
+    :type request: boofuzz.Request, optional
+    :param children: Children of this block, defaults to None
+    :type children: boofuzz.Fuzzable, optional
+    :param group: Name of group to associate this block with, defaults to None
+    :type group: str, optional
+    :param encoder: Optional pointer to a function to pass rendered data to prior to return, defaults to None
+    :type encoder: callable, optional
+    :param dep: Optional primitive whose specific value this block is dependant on, defaults to None
+    :type dep: str, optional
+    :param dep_value: Value that field "dep" must contain for block to be rendered, defaults to None
+    :type dep_value: Any, optional
+    :param dep_values: Values that field "dep" may contain for block to be rendered, defaults to None
+    :type dep_values: list, optional
+    :param dep_compare: Comparison method to apply to dependency (==, !=, >, >=, <, <=), defaults to None
+    :type dep_compare: str, optional
+    """
+
     def __init__(
         self,
-        name,
+        name=None,
         default_value=None,
         request=None,
+        children=None,
         group=None,
         encoder=None,
         dep=None,
@@ -18,25 +45,9 @@ class Block(FuzzableBlock):
         *args,
         **kwargs
     ):
-        """
-        The basic building block. Can contain primitives, sizers, checksums or other blocks.
-
-        @type  request:     Request
-        @param request:     Request this block belongs to
-        @type  group:       str
-        @param group:       (Optional, def=None) Name of group to associate this block with
-        @type  encoder:     Function Pointer
-        @param encoder:     (Optional, def=None) Optional pointer to a function to pass rendered data to prior to return
-        @type  dep:         str
-        @param dep:         (Optional, def=None) Optional primitive whose specific value this block is dependant on
-        @type  dep_value:   Mixed
-        @param dep_value:   (Optional, def=None) Value that field "dep" must contain for block to be rendered
-        @type  dep_values:  List of Mixed Types
-        @param dep_values:  (Optional, def=[]) Values that field "dep" may contain for block to be rendered
-        @type  dep_compare: str
-        @param dep_compare: (Optional, def="==") Comparison method to apply to dependency (==, !=, >, >=, <, <=)
-        """
-        super(Block, self).__init__(name=name, default_value=default_value, request=request, *args, **kwargs)
+        super(Block, self).__init__(
+            name=name, default_value=default_value, request=request, children=children, *args, **kwargs
+        )
 
         self.request = request
         self.group = group

--- a/boofuzz/blocks/checksum.py
+++ b/boofuzz/blocks/checksum.py
@@ -33,24 +33,34 @@ class Checksum(primitives.BasePrimitive):
     Recursive checksums are supported; the checksum field itself will render as all zeros for the sake of checksum
     or length calculations.
 
-    Args:
-        block_name (str): Name of target block for checksum calculations.
-        request (s_request): Request this block belongs to.
-        algorithm (str, function, optional): Checksum algorithm to use. (crc32, crc32c, adler32, md5, sha1, ipv4, udp)
-            Pass a function to use a custom algorithm. This function has to take and return byte-type data.
-        length (int, optional): Length of checksum, auto-calculated by default.
-            Must be specified manually when using custom algorithm.
-        endian (str, optional): Endianness of the bit field (LITTLE_ENDIAN: <, BIG_ENDIAN: >).
-            Defaults to LITTLE_ENDIAN.
-        ipv4_src_block_name (str): Required for 'udp' algorithm. Name of block yielding IPv4 source address.
-        ipv4_dst_block_name (str): Required for 'udp' algorithm. Name of block yielding IPv4 destination address.
+    :type  block_name: str
+    :param block_name: Name of target block for checksum calculations.
+    :type  request: boofuzz.Request
+    :param request: Request this block belongs to.
+    :type  algorithm: str, function, optional
+    :param algorithm: Checksum algorithm to use. (crc32, crc32c, adler32, md5, sha1, ipv4, udp)
+        Pass a function to use a custom algorithm. This function has to take and return byte-type data,
+        defaults to crc32
+    :type  length: int, optional
+    :param length: Length of checksum, auto-calculated by default. Must be specified manually when using custom
+        algorithm, defaults to 0
+    :type  endian: chr, optional
+    :param endian: Endianness of the bit field (LITTLE_ENDIAN: <, BIG_ENDIAN: >), defaults to LITTLE_ENDIAN
+    :type  ipv4_src_block_name: str, optional
+    :param ipv4_src_block_name: Required for 'udp' algorithm. Name of block yielding IPv4 source address,
+        defaults to None
+    :type  ipv4_dst_block_name: str, optional
+    :param ipv4_dst_block_name: Required for 'udp' algorithm. Name of block yielding IPv4 destination address,
+        defaults to None
+    :type  name: str
+    :param name: Name, for referencing later. Names should always be provided, but if not, a default name will be given,
+        defaults to None
     """
 
     checksum_lengths = {"crc32": 4, "crc32c": 4, "adler32": 4, "md5": 16, "sha1": 20, "ipv4": 2, "udp": 2}
 
     def __init__(
         self,
-        name,
         block_name,
         request,
         algorithm="crc32",
@@ -58,10 +68,11 @@ class Checksum(primitives.BasePrimitive):
         endian=LITTLE_ENDIAN,
         ipv4_src_block_name=None,
         ipv4_dst_block_name=None,
+        name=None,
         *args,
         **kwargs
     ):
-        super(Checksum, self).__init__(name, *args, **kwargs)
+        super(Checksum, self).__init__(name=name, *args, **kwargs)
 
         self._block_name = block_name
         self._request = request

--- a/boofuzz/blocks/checksum.py
+++ b/boofuzz/blocks/checksum.py
@@ -22,8 +22,7 @@ def _may_recurse(f):
 
 
 class Checksum(primitives.BasePrimitive):
-    """
-    Checksum bound to the block with the specified name.
+    """Checksum bound to the block with the specified name.
 
     The algorithm may be chosen by name with the algorithm parameter, or a custom function may be specified with
     the algorithm parameter.
@@ -33,9 +32,12 @@ class Checksum(primitives.BasePrimitive):
     Recursive checksums are supported; the checksum field itself will render as all zeros for the sake of checksum
     or length calculations.
 
+    :type  name: str, optional
+    :param name: Name, for referencing later. Names should always be provided, but if not, a default name will be given,
+        defaults to None
     :type  block_name: str
     :param block_name: Name of target block for checksum calculations.
-    :type  request: boofuzz.Request
+    :type  request: boofuzz.Request, optional
     :param request: Request this block belongs to.
     :type  algorithm: str, function, optional
     :param algorithm: Checksum algorithm to use. (crc32, crc32c, adler32, md5, sha1, ipv4, udp)
@@ -52,23 +54,22 @@ class Checksum(primitives.BasePrimitive):
     :type  ipv4_dst_block_name: str, optional
     :param ipv4_dst_block_name: Required for 'udp' algorithm. Name of block yielding IPv4 destination address,
         defaults to None
-    :type  name: str
-    :param name: Name, for referencing later. Names should always be provided, but if not, a default name will be given,
-        defaults to None
+    :type  fuzzable: bool, optional
+    :param fuzzable: Enable/disable fuzzing of this block, defaults to true
     """
 
     checksum_lengths = {"crc32": 4, "crc32c": 4, "adler32": 4, "md5": 16, "sha1": 20, "ipv4": 2, "udp": 2}
 
     def __init__(
         self,
-        block_name,
-        request,
+        name=None,
+        block_name=None,
+        request=None,
         algorithm="crc32",
         length=0,
         endian=LITTLE_ENDIAN,
         ipv4_src_block_name=None,
         ipv4_dst_block_name=None,
-        name=None,
         *args,
         **kwargs
     ):
@@ -108,7 +109,7 @@ class Checksum(primitives.BasePrimitive):
 
     def encode(self, value, mutation_context):
         if value is None:
-            if self._recursion_flag:
+            if self._recursion_flag or self._request is None:
                 self._rendered = self._get_dummy_value()
             else:
                 self._rendered = self._checksum(
@@ -127,7 +128,7 @@ class Checksum(primitives.BasePrimitive):
     def _render_block(self, block_name, mutation_context):
         return (
             self._request.resolve_name(self.context_path, block_name).render(mutation_context=mutation_context)
-            if block_name is not None
+            if block_name is not None and self._request is not None
             else None
         )
 

--- a/boofuzz/blocks/repeat.py
+++ b/boofuzz/blocks/repeat.py
@@ -6,40 +6,40 @@ from ..protocol_session_reference import ProtocolSessionReference
 
 
 class Repeat(Fuzzable):
-    """
-    Repeat the rendered contents of the specified block cycling from min_reps to max_reps counting by step. By
+    """Repeat the rendered contents of the specified block cycling from min_reps to max_reps counting by step. By
     default renders to nothing. This block modifier is useful for fuzzing overflows in table entries. This block
     modifier MUST come after the block it is being applied to.
 
-    @type  block_name: str
-    @param block_name: Name of block to repeat
-    @type  request:    s_request
-    @param request:    Request this block belongs to
-    @type  min_reps:   int
-    @param min_reps:   (Optional, def=0) Minimum number of block repetitions
-    @type  max_reps:   int
-    @param max_reps:   (Optional, def=None) Maximum number of block repetitions
-    @type  step:       int
-    @param step:       (Optional, def=1) Step count between min and max reps
-    @type  variable:   Sulley Integer Primitive
-    @param variable:   (Optional, def=None) Repetitions will be derived from this variable, disables fuzzing
-    @type  fuzzable:   bool
-    @param fuzzable:   (Optional, def=True) Enable/disable fuzzing of this primitive
-    @type  name:       str
-    @param name:       (Optional, def=None) Specifying a name gives you direct access to a primitive
+    :param block_name: Name of block to repeat
+    :type block_name: str
+    :param request: Request this block belongs to, defaults to None
+    :type request: boofuzz.Request, optional
+    :param min_reps: Minimum number of block repetitions, defaults to 0
+    :type min_reps: int, optional
+    :param max_reps: Maximum number of block repetitions, defaults to None
+    :type max_reps: int, optional
+    :param step: Step count between min and max reps, defaults to 1
+    :type step: int, optional
+    :param variable: Repetitions will be derived from this variable, disables fuzzing, defaults to None
+    :type variable: Boofuzz Integer Primitive, optional
+    :param default_value: Value used when the element is not being fuzzed – should typically represent a valid value,
+        defaults to None
+    :type default_value: Raw
+    :param name: Name, for referencing later. Names should always be provided, but if not, a default name will be given,
+        defaults to None
+    :type name: str
     """
 
     def __init__(
         self,
-        name,
         block_name,
         request,
         min_reps=0,
         max_reps=None,
         step=1,
         variable=None,
-        fuzzable=True,
         default_value=None,
+        name=None,
         *args,
         **kwargs
     ):
@@ -49,14 +49,13 @@ class Repeat(Fuzzable):
             else:
                 default_value = 0
 
-        super(Repeat, self).__init__(name, default_value, *args, **kwargs)
+        super(Repeat, self).__init__(name=name, default_value=default_value, *args, **kwargs)
 
         self.block_name = block_name
         self.request = request
         self.min_reps = min_reps
         self.max_reps = max_reps
         self.step = step
-        self._fuzzable = fuzzable
         self._name = name
 
         self._value = b""
@@ -69,10 +68,6 @@ class Repeat(Fuzzable):
 
         if self.max_reps is not None:
             self._fuzz_library = range(self.min_reps, self.max_reps + 1, self.step)
-
-    @property
-    def fuzzable(self):
-        return self._fuzzable
 
     def mutations(self, default_value):
         for fuzzed_reps_number in self._fuzz_library:

--- a/boofuzz/blocks/repeat.py
+++ b/boofuzz/blocks/repeat.py
@@ -22,7 +22,7 @@ class Repeat(Fuzzable):
     :type step: int, optional
     :param variable: Repetitions will be derived from this variable, disables fuzzing, defaults to None
     :type variable: Boofuzz Integer Primitive, optional
-    :param default_value: Value used when the element is not being fuzzed – should typically represent a valid value,
+    :param default_value: Value used when the element is not being fuzzed - should typically represent a valid value,
         defaults to None
     :type default_value: Raw
     :param name: Name, for referencing later. Names should always be provided, but if not, a default name will be given,

--- a/boofuzz/blocks/request.py
+++ b/boofuzz/blocks/request.py
@@ -20,7 +20,7 @@ class Request(FuzzableBlock):
     """
 
     def __init__(self, name, children=None):
-        super(Request, self).__init__(name=name)
+        super(Request, self).__init__(name=name, request=self)
         self._name = name
         self.label = name  # node label for graph rendering.
         self.stack = []  # the request stack.

--- a/boofuzz/blocks/request.py
+++ b/boofuzz/blocks/request.py
@@ -10,16 +10,17 @@ from ..fuzzable_block import FuzzableBlock
 
 
 class Request(FuzzableBlock):
+    """Top level container. Can hold any block structure or primitive. This can
+    essentially be thought of as a super-block, root-block, daddy-block or whatever other alias you prefer.
+
+    :param name: Name of this request
+    :type name: str
+    :param children: Children of this request, defaults to None
+    :type children: boofuzz.Fuzzable, optional
+    """
+
     def __init__(self, name, children=None):
-        """
-        Top level container instantiated by s_initialize(). Can hold any block structure or primitive. This can
-        essentially be thought of as a super-block, root-block, daddy-block or whatever other alias you prefer.
-
-        @type  name: str
-        @param name: Name of this request
-        """
-
-        super(Request, self).__init__(name, self)
+        super(Request, self).__init__(name=name)
         self._name = name
         self.label = name  # node label for graph rendering.
         self.stack = []  # the request stack.

--- a/boofuzz/blocks/request.py
+++ b/boofuzz/blocks/request.py
@@ -10,18 +10,18 @@ from ..fuzzable_block import FuzzableBlock
 
 
 class Request(FuzzableBlock):
-    """Top level container. Can hold any block structure or primitive. This can
-    essentially be thought of as a super-block, root-block, daddy-block or whatever other alias you prefer.
+    """Top level container. Can hold any block structure or primitive.
+
+    This can essentially be thought of as a super-block, root-block, daddy-block or whatever other alias you prefer.
 
     :param name: Name of this request
-    :type name: str
+    :type name: str, optional
     :param children: Children of this request, defaults to None
     :type children: boofuzz.Fuzzable, optional
     """
 
-    def __init__(self, name, children=None):
+    def __init__(self, name=None, children=None):
         super(Request, self).__init__(name=name, request=self)
-        self._name = name
         self.label = name  # node label for graph rendering.
         self.stack = []  # the request stack.
         self.block_stack = []  # list of open blocks, -1 is last open block.
@@ -167,6 +167,8 @@ class Request(FuzzableBlock):
         Returns:
 
         """
+        if name is None:
+            raise BoofuzzNameResolutionError(ERR_NAME_NOT_FOUND.format(name))
         if name.startswith("."):  # Case 1 relative
             components = (context_path + name).split(".")  # double dots leave an empty string; so do trailing dots
             while "" in components:

--- a/boofuzz/blocks/size.py
+++ b/boofuzz/blocks/size.py
@@ -16,14 +16,34 @@ def _may_recurse(f):
 
 
 class Size(Fuzzable):
-    """
-    This block type is kind of special in that it is a hybrid between a block and a primitive (it can be fuzzed). The
-    user does not need to be wary of this fact.
+    """Create a sizer block bound to the block with the specified name. Size blocks that size their own parent or
+    grandparent are allowed.
+
+    :type  block_name:    str
+    :param block_name:    Name of block to apply sizer to.
+    :type  request:       boofuzz.Request
+    :param request:       Request this block belongs to.
+    :type  offset:        int, optional
+    :param offset:        Offset for calculated size value, defaults to 0
+    :type  length:        int, optional
+    :param length:        Length of sizer, defaults to 4
+    :type  endian:        chr, optional
+    :param endian:        Endianness of the bit field (LITTLE_ENDIAN: <, BIG_ENDIAN: >), defaults to LITTLE_ENDIAN
+    :type  output_format: str, optional
+    :param output_format: Output format, "binary" or "ascii", defaults to binary
+    :type  inclusive:     bool, optional
+    :param inclusive:     Should the sizer count its own length? Defaults to False
+    :type  signed:        bool, optional
+    :param signed:        Make size signed vs. unsigned (applicable only with format="ascii"), defaults to False
+    :type  math:          def, optional
+    :param math:          Apply the mathematical op defined in this function to the size, defaults to None
+    :type name: str
+    :param name: Name, for referencing later. Names should always be provided, but if not, a default name will be given,
+        defaults to None
     """
 
     def __init__(
         self,
-        name,
         block_name,
         request=None,
         offset=0,
@@ -33,33 +53,10 @@ class Size(Fuzzable):
         inclusive=False,
         signed=False,
         math=None,
+        name=None,
         *args,
         **kwargs
     ):
-        """
-        Create a sizer block bound to the block with the specified name. Size blocks that size their own parent or
-        grandparent are allowed.
-
-        :type  block_name:    str
-        :param block_name:    Name of block to apply sizer to
-        :type  request:       Request
-        :param request:       Request this block belongs to
-        :type  length:        int
-        :param length:        (Optional, def=4) Length of sizer
-        :type  offset:        int
-        :param offset:        (Optional, def=0) Offset for calculated size value
-        :type  endian:        chr
-        :param endian:        (Optional, def=LITTLE_ENDIAN) Endianess of the bit field (LITTLE_ENDIAN: <, BIG_ENDIAN: >)
-        :type  output_format: str
-        :param output_format: (Optional, def=binary) Output format, "binary" or "ascii"
-        :type  inclusive:     bool
-        :param inclusive:     (Optional, def=False) Should the sizer count its own length?
-        :type  signed:        bool
-        :param signed:        (Optional, def=False) Make size signed vs. unsigned (applicable only with format="ascii")
-        :type  math:          def
-        :param math:          (Optional, def=None) Apply the mathematical op defined in this function to the size
-        """
-
         super(Size, self).__init__(name=name, default_value=None, *args, **kwargs)
         self.block_name = block_name
         self.request = request

--- a/boofuzz/blocks/size.py
+++ b/boofuzz/blocks/size.py
@@ -1,7 +1,6 @@
 from functools import wraps
 
 from .. import helpers, primitives
-from ..exception import BoofuzzNameResolutionError
 from ..fuzzable import Fuzzable
 
 

--- a/boofuzz/fuzzable.py
+++ b/boofuzz/fuzzable.py
@@ -22,13 +22,16 @@ class Fuzzable(object):
 
     The rest of the methods are used by boofuzz to handle fuzzing and are typically not overridden.
 
-    Args:
-        fuzzable (bool): Enable fuzzing of this primitive. Default: True.
-        name (str): Name, for referencing later. Names should always be provided, but if not, a default name will
-            be given.
-        default_value: Value used when the element is not being fuzzed -- should typically represent a valid value.
-            Can be a static value, or a ReferenceValueTestCaseSession.
-        fuzz_values (list): List of custom fuzz values to add to the normal mutations.
+    :type name: str, optional
+    :param name: Name, for referencing later. Names should always be provided, but if not, a default name will be given,
+        defaults to None
+    :type default_value: Any
+    :param default_value: Value used when the element is not being fuzzed -- should typically represent a valid value.
+        Can be a static value, or a ReferenceValueTestCaseSession, defaults to None
+    :type fuzzable: bool
+    :param fuzzable: Enable fuzzing of this primitive, defaults to True
+    :type fuzz_values: list
+    :param fuzz_values: List of custom fuzz values to add to the normal mutations, defaults to None
     """
 
     name_counter = 0

--- a/boofuzz/fuzzable.py
+++ b/boofuzz/fuzzable.py
@@ -7,7 +7,7 @@ from .protocol_session_reference import ProtocolSessionReference
 
 
 class Fuzzable(object):
-    """Parent class for all primivites and blocks.
+    """Parent class for all primitives and blocks.
 
     When making new fuzzable types, one will typically override :meth:`mutations` and/or :meth:`encode`.
 
@@ -47,6 +47,10 @@ class Fuzzable(object):
             fuzz_values = list()
         self._fuzz_values = fuzz_values
 
+        if self._name is None:
+            Fuzzable.name_counter += 1
+            self._name = "{0}{1}".format(type(self).__name__, Fuzzable.name_counter)
+
     @property
     def fuzzable(self):
         """If False, this element should not be mutated in normal fuzzing."""
@@ -58,9 +62,9 @@ class Fuzzable(object):
 
         :rtype: str
         """
-        if self._name is None:
-            Fuzzable.name_counter += 1
-            self._name = "{0}{1}".format(type(self).__name__, Fuzzable.name_counter)
+        # if self._name is None:
+        #     Fuzzable.name_counter += 1
+        #     self._name = "{0}{1}".format(type(self).__name__, Fuzzable.name_counter)
         return self._name
 
     @property

--- a/boofuzz/fuzzable.py
+++ b/boofuzz/fuzzable.py
@@ -26,7 +26,7 @@ class Fuzzable(object):
     :param name: Name, for referencing later. Names should always be provided, but if not, a default name will be given,
         defaults to None
     :type default_value: Any
-    :param default_value: Value used when the element is not being fuzzed -- should typically represent a valid value.
+    :param default_value: Value used when the element is not being fuzzed - should typically represent a valid value.
         Can be a static value, or a ReferenceValueTestCaseSession, defaults to None
     :type fuzzable: bool
     :param fuzzable: Enable fuzzing of this primitive, defaults to True

--- a/boofuzz/fuzzable_block.py
+++ b/boofuzz/fuzzable_block.py
@@ -15,11 +15,16 @@ class FuzzableBlock(Fuzzable):
     1. :meth:`get_child_data` Render and concatenate all child nodes.
     2. :meth:`push` Add an additional child node; generally used only internally.
 
-    Args:
-        children (Iterable): List of child nodes (typically given to FuzzableBlock types).
+    :param name: Name, for referencing later. Names should always be provided, but if not, a default name will be given,
+        defaults to None
+    :type name: str
+    :param request: Request this block belongs to, defaults to None
+    :type request: boofuzz.Request, optional
+    :param children: List of child nodes (typically given to FuzzableBlock types)m defaults to None
+    :type children: boofuzz.Fuzzable, optional
     """
 
-    def __init__(self, name, request=None, children=None, *args, **kwargs):
+    def __init__(self, name=None, request=None, children=None, *args, **kwargs):
         super(FuzzableBlock, self).__init__(name, *args, **kwargs)
         self.request = request
 

--- a/boofuzz/fuzzable_block.py
+++ b/boofuzz/fuzzable_block.py
@@ -17,7 +17,7 @@ class FuzzableBlock(Fuzzable):
 
     :param name: Name, for referencing later. Names should always be provided, but if not, a default name will be given,
         defaults to None
-    :type name: str
+    :type name: str, optional
     :param request: Request this block belongs to, defaults to None
     :type request: boofuzz.Request, optional
     :param children: List of child nodes (typically given to FuzzableBlock types)m defaults to None
@@ -25,7 +25,7 @@ class FuzzableBlock(Fuzzable):
     """
 
     def __init__(self, name=None, request=None, children=None, *args, **kwargs):
-        super(FuzzableBlock, self).__init__(name, *args, **kwargs)
+        super(FuzzableBlock, self).__init__(name=name, *args, **kwargs)
         self.request = request
 
         if children is None:

--- a/boofuzz/primitives/bit_field.py
+++ b/boofuzz/primitives/bit_field.py
@@ -42,10 +42,13 @@ class BitField(Fuzzable):
     """
     The bit field primitive represents a number of variable length and is used to define all other integer types.
 
-    :type  default_value: int
-    :param default_value: Default integer value
-    :type  width: int
-    :param width: Width in bits
+    :type  name: str, optional
+    :param name: Name, for referencing later. Names should always be provided, but if not, a default name will be given,
+        defaults to None
+    :type  default_value: int, optional
+    :param default_value: Default integer value, defaults to 0
+    :type  width: int, optional
+    :param width: Width in bits, defaults to 8
     :type  max_num: int, optional
     :param max_num: Maximum number to iterate up to, defaults to None
     :type  endian: char, optional
@@ -56,27 +59,26 @@ class BitField(Fuzzable):
     :param signed: Make size signed vs. unsigned (applicable only with format="ascii"), defaults to False
     :type  full_range: bool, optional
     :param full_range: If enabled the field mutates through *all* possible values, defaults to False
-    :type fuzz_values: list, optional
+    :type  fuzz_values: list, optional
     :param fuzz_values: List of custom fuzz values to add to the normal mutations, defaults to None
-    :type name: str, optional
-    :param name: Name, for referencing later. Names should always be provided, but if not, a default name will be given,
-        defaults to None
+    :type  fuzzable: bool, optional
+    :param fuzzable: Enable/disable fuzzing of this primitive, defaults to true
     """
 
     def __init__(
         self,
-        default_value,
-        width,
+        name=None,
+        default_value=0,
+        width=8,
         max_num=None,
         endian=LITTLE_ENDIAN,
         output_format="binary",
         signed=False,
         full_range=False,
-        name=None,
         *args,
         **kwargs
     ):
-        super(BitField, self).__init__(name, default_value, *args, **kwargs)
+        super(BitField, self).__init__(name=name, default_value=default_value, *args, **kwargs)
 
         assert isinstance(width, six.integer_types), "width must be an integer!"
 

--- a/boofuzz/primitives/bit_field.py
+++ b/boofuzz/primitives/bit_field.py
@@ -39,9 +39,32 @@ def int_to_binary_string(number, bit_width):
 
 
 class BitField(Fuzzable):
+    """
+    The bit field primitive represents a number of variable length and is used to define all other integer types.
+
+    :type  default_value: int
+    :param default_value: Default integer value
+    :type  width: int
+    :param width: Width in bits
+    :type  max_num: int, optional
+    :param max_num: Maximum number to iterate up to, defaults to None
+    :type  endian: char, optional
+    :param endian: Endianness of the bit field (LITTLE_ENDIAN: <, BIG_ENDIAN: >), defaults to LITTLE_ENDIAN
+    :type  output_format: str, optional
+    :param output_format: Output format, "binary" or "ascii", defaults to binary
+    :type  signed: bool, optional
+    :param signed: Make size signed vs. unsigned (applicable only with format="ascii"), defaults to False
+    :type  full_range: bool, optional
+    :param full_range: If enabled the field mutates through *all* possible values, defaults to False
+    :type fuzz_values: list, optional
+    :param fuzz_values: List of custom fuzz values to add to the normal mutations, defaults to None
+    :type name: str, optional
+    :param name: Name, for referencing later. Names should always be provided, but if not, a default name will be given,
+        defaults to None
+    """
+
     def __init__(
         self,
-        name,
         default_value,
         width,
         max_num=None,
@@ -49,25 +72,10 @@ class BitField(Fuzzable):
         output_format="binary",
         signed=False,
         full_range=False,
+        name=None,
         *args,
         **kwargs
     ):
-        """
-        The bit field primitive represents a number of variable length and is used to define all other integer types.
-
-        @type  width:         int
-        @param width:         Width in bits
-        @type  max_num:       int
-        @param max_num:       Maximum number to iterate up to
-        @type  endian:        chr
-        @param endian:        (Optional, def=LITTLE_ENDIAN) Endianess of the bit field (LITTLE_ENDIAN: <, BIG_ENDIAN: >)
-        @type  output_format: str
-        @param output_format: (Optional, def=binary) Output format, "binary" or "ascii"
-        @type  signed:        bool
-        @param signed:        (Optional, def=False) Make size signed vs. unsigned (applicable only with format="ascii")
-        @type  full_range:    bool
-        @param full_range:    (Optional, def=False) If enabled the field mutates through *all* possible values.
-        """
         super(BitField, self).__init__(name, default_value, *args, **kwargs)
 
         assert isinstance(width, six.integer_types), "width must be an integer!"

--- a/boofuzz/primitives/byte.py
+++ b/boofuzz/primitives/byte.py
@@ -6,11 +6,11 @@ from .bit_field import BitField
 
 
 class Byte(BitField):
-    def __init__(self, *args, **kwargs):
-        # Inject the one parameter we care to pass in (width)
-        kwargs["width"] = 8
+    """The byte sized bit field primitive. Inherits parameters from :class:`boofuzz.BitField`"""
 
-        super(Byte, self).__init__(*args, **kwargs)
+    def __init__(self, default_value, *args, **kwargs):
+        # Inject the one parameter we care to pass in (width)
+        super(Byte, self).__init__(default_value=default_value, width=8, *args, **kwargs)
 
     def encode(self, value, mutation_context):
         if not isinstance(value, (six.integer_types, list, tuple)):

--- a/boofuzz/primitives/byte.py
+++ b/boofuzz/primitives/byte.py
@@ -6,11 +6,32 @@ from .bit_field import BitField
 
 
 class Byte(BitField):
-    """The byte sized bit field primitive. Inherits parameters from :class:`boofuzz.BitField`"""
+    """The byte sized bit field primitive.
 
-    def __init__(self, default_value, *args, **kwargs):
+    :type  name: str, optional
+    :param name: Name, for referencing later. Names should always be provided, but if not, a default name will be given,
+        defaults to None
+    :type  default_value: int, optional
+    :param default_value: Default integer value, defaults to 0
+    :type  max_num: int, optional
+    :param max_num: Maximum number to iterate up to, defaults to None
+    :type  endian: char, optional
+    :param endian: Endianness of the bit field (LITTLE_ENDIAN: <, BIG_ENDIAN: >), defaults to LITTLE_ENDIAN
+    :type  output_format: str, optional
+    :param output_format: Output format, "binary" or "ascii", defaults to binary
+    :type  signed: bool, optional
+    :param signed: Make size signed vs. unsigned (applicable only with format="ascii"), defaults to False
+    :type  full_range: bool, optional
+    :param full_range: If enabled the field mutates through *all* possible values, defaults to False
+    :type  fuzz_values: list, optional
+    :param fuzz_values: List of custom fuzz values to add to the normal mutations, defaults to None
+    :type  fuzzable: bool, optional
+    :param fuzzable: Enable/disable fuzzing of this primitive, defaults to true
+    """
+
+    def __init__(self, *args, **kwargs):
         # Inject the one parameter we care to pass in (width)
-        super(Byte, self).__init__(default_value=default_value, width=8, *args, **kwargs)
+        super(Byte, self).__init__(width=8, *args, **kwargs)
 
     def encode(self, value, mutation_context):
         if not isinstance(value, (six.integer_types, list, tuple)):

--- a/boofuzz/primitives/bytes.py
+++ b/boofuzz/primitives/bytes.py
@@ -7,6 +7,21 @@ from ..fuzzable import Fuzzable
 
 
 class Bytes(Fuzzable):
+    """Primitive that fuzzes a binary byte string with arbitrary length.
+
+    :type default_value: bytes
+    :param default_value: Value used when the element is not being fuzzed – should typically represent a valid value.
+    :type size: int, optional
+    :param size: Static size of this field, leave None for dynamic, defaults to None
+    :type padding: chr, optional
+    :param padding: Value to use as padding to fill static field size, defaults to b"\\x00"
+    :type max_len: int, optional
+    :param max_len: Maximum string length, defaults to None
+    :type name: str, optional
+    :param name: Name, for referencing later. Names should always be provided, but if not, a default name will be given,
+        defaults to None
+    """
+
     # This binary strings will always included as testcases.
     _fuzz_library = [
         b"",
@@ -101,19 +116,8 @@ class Bytes(Fuzzable):
         functools.partial(operator.mul, 100),
     ]
 
-    def __init__(self, name, default_value, size=None, padding=b"\x00", max_len=None, *args, **kwargs):
-        """
-        Primitive that fuzzes a binary byte string with arbitrary length.
-
-        @type  size:       int
-        @param size:       (Optional, def=None) Static size of this field, leave None for dynamic.
-        @type  padding:    chr
-        @param padding:    (Optional, def=b"\\x00") Value to use as padding to fill static field size.
-        @type  max_len:    int
-        @param max_len:    (Optional, def=None) Maximum string length
-        """
-
-        super(Bytes, self).__init__(name, default_value, *args, **kwargs)
+    def __init__(self, default_value, size=None, padding=b"\x00", max_len=None, name=None, *args, **kwargs):
+        super(Bytes, self).__init__(name=name, default_value=default_value, *args, **kwargs)
 
         self.size = size
         self.max_len = max_len

--- a/boofuzz/primitives/bytes.py
+++ b/boofuzz/primitives/bytes.py
@@ -9,17 +9,20 @@ from ..fuzzable import Fuzzable
 class Bytes(Fuzzable):
     """Primitive that fuzzes a binary byte string with arbitrary length.
 
-    :type default_value: bytes
-    :param default_value: Value used when the element is not being fuzzed - should typically represent a valid value.
+    :type name: str, optional
+    :param name: Name, for referencing later. Names should always be provided, but if not, a default name will be given,
+        defaults to None
+    :type default_value: bytes, optional
+    :param default_value: Value used when the element is not being fuzzed - should typically represent a valid value,
+        defaults to b""
     :type size: int, optional
     :param size: Static size of this field, leave None for dynamic, defaults to None
     :type padding: chr, optional
     :param padding: Value to use as padding to fill static field size, defaults to b"\\x00"
     :type max_len: int, optional
     :param max_len: Maximum string length, defaults to None
-    :type name: str, optional
-    :param name: Name, for referencing later. Names should always be provided, but if not, a default name will be given,
-        defaults to None
+    :type fuzzable: bool, optional
+    :param fuzzable: Enable/disable fuzzing of this primitive, defaults to true
     """
 
     # This binary strings will always included as testcases.
@@ -116,7 +119,7 @@ class Bytes(Fuzzable):
         functools.partial(operator.mul, 100),
     ]
 
-    def __init__(self, default_value, size=None, padding=b"\x00", max_len=None, name=None, *args, **kwargs):
+    def __init__(self, name=None, default_value=b"", size=None, padding=b"\x00", max_len=None, *args, **kwargs):
         super(Bytes, self).__init__(name=name, default_value=default_value, *args, **kwargs)
 
         self.size = size

--- a/boofuzz/primitives/bytes.py
+++ b/boofuzz/primitives/bytes.py
@@ -10,7 +10,7 @@ class Bytes(Fuzzable):
     """Primitive that fuzzes a binary byte string with arbitrary length.
 
     :type default_value: bytes
-    :param default_value: Value used when the element is not being fuzzed – should typically represent a valid value.
+    :param default_value: Value used when the element is not being fuzzed - should typically represent a valid value.
     :type size: int, optional
     :param size: Static size of this field, leave None for dynamic, defaults to None
     :type padding: chr, optional

--- a/boofuzz/primitives/delim.py
+++ b/boofuzz/primitives/delim.py
@@ -5,26 +5,25 @@ from .. import helpers
 class Delim(BasePrimitive):
     r"""Represent a delimiter such as :,\r,\n, ,=,>,< etc... Mutations include repetition, substitution and exclusion.
 
-    :param default_value: Value used when the element is not being fuzzed - should typically represent a valid value.
-    :type default_value: char, optional
     :param name: Name, for referencing later. Names should always be provided, but if not, a default name will be given,
         defaults to None
     :type name: str, optional
+    :param default_value: Value used when the element is not being fuzzed - should typically represent a valid value.
+    :type default_value: char, optional
+    :param fuzzable: Enable/disable fuzzing of this primitive, defaults to true
+    :type fuzzable: bool, optional
     """
 
-    def __init__(self, default_value, name=None, *args, **kwargs):
+    def __init__(self, name=None, default_value=" ", *args, **kwargs):
         super(Delim, self).__init__(name=name, default_value=default_value, *args, **kwargs)
 
-        self._default_value = default_value
-
-        if self._default_value:
-            self._fuzz_library.append(self._default_value * 2)
-            self._fuzz_library.append(self._default_value * 5)
-            self._fuzz_library.append(self._default_value * 10)
-            self._fuzz_library.append(self._default_value * 25)
-            self._fuzz_library.append(self._default_value * 100)
-            self._fuzz_library.append(self._default_value * 500)
-            self._fuzz_library.append(self._default_value * 1000)
+        self._fuzz_library.append(self._default_value * 2)
+        self._fuzz_library.append(self._default_value * 5)
+        self._fuzz_library.append(self._default_value * 10)
+        self._fuzz_library.append(self._default_value * 25)
+        self._fuzz_library.append(self._default_value * 100)
+        self._fuzz_library.append(self._default_value * 500)
+        self._fuzz_library.append(self._default_value * 1000)
 
         self._fuzz_library.append("")
         if self._default_value == " ":

--- a/boofuzz/primitives/delim.py
+++ b/boofuzz/primitives/delim.py
@@ -5,7 +5,7 @@ from .. import helpers
 class Delim(BasePrimitive):
     r"""Represent a delimiter such as :,\r,\n, ,=,>,< etc... Mutations include repetition, substitution and exclusion.
 
-    :param default_value: Value used when the element is not being fuzzed – should typically represent a valid value.
+    :param default_value: Value used when the element is not being fuzzed - should typically represent a valid value.
     :type default_value: char, optional
     :param name: Name, for referencing later. Names should always be provided, but if not, a default name will be given,
         defaults to None

--- a/boofuzz/primitives/delim.py
+++ b/boofuzz/primitives/delim.py
@@ -3,15 +3,17 @@ from .. import helpers
 
 
 class Delim(BasePrimitive):
-    def __init__(self, name, default_value, *args, **kwargs):
-        """
-        Represent a delimiter such as :,\r,\n, ,=,>,< etc... Mutations include repetition, substitution and exclusion.
+    r"""Represent a delimiter such as :,\r,\n, ,=,>,< etc... Mutations include repetition, substitution and exclusion.
 
-        @type  default_value:    chr
-        @param default_value:    Original value
-        """
+    :param default_value: Value used when the element is not being fuzzed – should typically represent a valid value.
+    :type default_value: char, optional
+    :param name: Name, for referencing later. Names should always be provided, but if not, a default name will be given,
+        defaults to None
+    :type name: str, optional
+    """
 
-        super(Delim, self).__init__(name, default_value, *args, **kwargs)
+    def __init__(self, default_value, name=None, *args, **kwargs):
+        super(Delim, self).__init__(name=name, default_value=default_value, *args, **kwargs)
 
         self._default_value = default_value
 

--- a/boofuzz/primitives/dword.py
+++ b/boofuzz/primitives/dword.py
@@ -6,11 +6,32 @@ from boofuzz.primitives.bit_field import BitField
 
 
 class DWord(BitField):
-    """The 4 byte sized bit field primitive. Inherits parameters from :class:`boofuzz.BitField`"""
+    """The 4 byte sized bit field primitive.
 
-    def __init__(self, default_value, *args, **kwargs):
+    :type  name: str, optional
+    :param name: Name, for referencing later. Names should always be provided, but if not, a default name will be given,
+        defaults to None
+    :type  default_value: int, optional
+    :param default_value: Default integer value, defaults to 0
+    :type  max_num: int, optional
+    :param max_num: Maximum number to iterate up to, defaults to None
+    :type  endian: char, optional
+    :param endian: Endianness of the bit field (LITTLE_ENDIAN: <, BIG_ENDIAN: >), defaults to LITTLE_ENDIAN
+    :type  output_format: str, optional
+    :param output_format: Output format, "binary" or "ascii", defaults to binary
+    :type  signed: bool, optional
+    :param signed: Make size signed vs. unsigned (applicable only with format="ascii"), defaults to False
+    :type  full_range: bool, optional
+    :param full_range: If enabled the field mutates through *all* possible values, defaults to False
+    :type  fuzz_values: list, optional
+    :param fuzz_values: List of custom fuzz values to add to the normal mutations, defaults to None
+    :type  fuzzable: bool, optional
+    :param fuzzable: Enable/disable fuzzing of this primitive, defaults to true
+    """
+
+    def __init__(self, *args, **kwargs):
         # Inject our width argument
-        super(DWord, self).__init__(default_value=default_value, width=32, *args, **kwargs)
+        super(DWord, self).__init__(width=32, *args, **kwargs)
 
     def encode(self, value, mutation_context):
         if not isinstance(value, (six.integer_types, list, tuple)):

--- a/boofuzz/primitives/dword.py
+++ b/boofuzz/primitives/dword.py
@@ -6,11 +6,11 @@ from boofuzz.primitives.bit_field import BitField
 
 
 class DWord(BitField):
-    def __init__(self, *args, **kwargs):
-        # Inject our width argument
-        kwargs["width"] = 32
+    """The 4 byte sized bit field primitive. Inherits parameters from :class:`boofuzz.BitField`"""
 
-        super(DWord, self).__init__(*args, **kwargs)
+    def __init__(self, default_value, *args, **kwargs):
+        # Inject our width argument
+        super(DWord, self).__init__(default_value=default_value, width=32, *args, **kwargs)
 
     def encode(self, value, mutation_context):
         if not isinstance(value, (six.integer_types, list, tuple)):

--- a/boofuzz/primitives/from_file.py
+++ b/boofuzz/primitives/from_file.py
@@ -5,34 +5,39 @@ from .base_primitive import BasePrimitive
 
 
 class FromFile(BasePrimitive):
-    """Cycles through a list of "bad" values from a file(s). Takes filename and open the file(s) to read
-    the values to use in fuzzing process. filename may contain glob characters.
+    """Cycles through a list of "bad" values from a file(s).
 
-    :type default_value: str
+    Takes filename and open the file(s) to read the values to use in fuzzing process. filename may contain glob
+    characters.
+
+    :type  name: str, optional
+    :param name: Name, for referencing later. Names should always be provided, but if not, a default name will be given,
+        defaults to None
+    :type  default_value: str
     :param default_value: Default string value
     :type  filename: str
     :param filename: Filename pattern to load all fuzz value
     :type  max_len: int, optional
     :param max_len: Maximum string length, defaults to 0
-    :type name: str, optional
-    :param name: Name, for referencing later. Names should always be provided, but if not, a default name will be given,
-        defaults to None
+    :type  fuzzable: bool, optional
+    :param fuzzable: Enable/disable fuzzing of this primitive, defaults to true
     """
 
-    def __init__(self, default_value, filename, max_len=0, name=None, *args, **kwargs):
+    def __init__(self, name=None, default_value="", filename=None, max_len=0, *args, **kwargs):
 
         super(FromFile, self).__init__(name=name, default_value=default_value, *args, **kwargs)
 
         self._filename = filename
         self._fuzz_library = []
-        list_of_files = glob.glob(self._filename)
-        for fname in list_of_files:
-            with open(fname, "rb") as _file_handle:
-                self._fuzz_library.extend(list(filter(None, _file_handle.read().splitlines())))
+        if self._filename is not None:
+            list_of_files = glob.glob(self._filename)
+            for fname in list_of_files:
+                with open(fname, "rb") as _file_handle:
+                    self._fuzz_library.extend(list(filter(None, _file_handle.read().splitlines())))
 
-        # TODO: Make this more clear
-        if max_len > 0:
-            # If any of our strings are over max_len
-            if any(len(s) > max_len for s in self._fuzz_library):
-                # Pull out only the ones that aren't
-                self._fuzz_library = list(set([s for s in self._fuzz_library if len(s) <= max_len]))
+            # TODO: Make this more clear
+            if max_len > 0:
+                # If any of our strings are over max_len
+                if any(len(s) > max_len for s in self._fuzz_library):
+                    # Pull out only the ones that aren't
+                    self._fuzz_library = list(set([s for s in self._fuzz_library if len(s) <= max_len]))

--- a/boofuzz/primitives/from_file.py
+++ b/boofuzz/primitives/from_file.py
@@ -5,22 +5,24 @@ from .base_primitive import BasePrimitive
 
 
 class FromFile(BasePrimitive):
-    def __init__(self, name, value, max_len=0, filename=None, *args, **kwargs):
-        """
-        Cycles through a list of "bad" values from a file(s). Takes filename and open the file(s) to read
-        the values to use in fuzzing process. filename may contain glob characters.
+    """Cycles through a list of "bad" values from a file(s). Takes filename and open the file(s) to read
+    the values to use in fuzzing process. filename may contain glob characters.
 
-        @type  value:    str
-        @param value:    Default string value
-        @type  max_len:  int
-        @param max_len:  (Optional, def=0) Maximum string length
-        @type  filename: str
-        @param filename: Filename pattern to load all fuzz value
-        """
+    :type default_value: str
+    :param default_value: Default string value
+    :type  filename: str
+    :param filename: Filename pattern to load all fuzz value
+    :type  max_len: int, optional
+    :param max_len: Maximum string length, defaults to 0
+    :type name: str, optional
+    :param name: Name, for referencing later. Names should always be provided, but if not, a default name will be given,
+        defaults to None
+    """
 
-        super(FromFile, self).__init__(name, value, *args, **kwargs)
+    def __init__(self, default_value, filename, max_len=0, name=None, *args, **kwargs):
 
-        self._default_value = value
+        super(FromFile, self).__init__(name=name, default_value=default_value, *args, **kwargs)
+
         self._filename = filename
         self._fuzz_library = []
         list_of_files = glob.glob(self._filename)

--- a/boofuzz/primitives/group.py
+++ b/boofuzz/primitives/group.py
@@ -10,7 +10,7 @@ class Group(BasePrimitive):
 
     :param values: List of possible raw values this group can take.
     :type values: list of bytes or list of str
-    :param default_value: Value used when the element is not being fuzzed – should typically represent a valid value,
+    :param default_value: Value used when the element is not being fuzzed - should typically represent a valid value,
         defaults to None
     :type default_value: str, optional
     :param encoding: String encoding, ex: utf_16_le for Microsoft Unicode, defaults to ascii

--- a/boofuzz/primitives/group.py
+++ b/boofuzz/primitives/group.py
@@ -4,21 +4,23 @@ from .base_primitive import BasePrimitive
 
 
 class Group(BasePrimitive):
-    def __init__(self, name, values, default_value=None, encoding="ascii", *args, **kwargs):
-        """
-        This primitive represents a list of static values, stepping through each one on mutation. You can tie a block
-        to a group primitive to specify that the block should cycle through all possible mutations for *each* value
-        within the group. The group primitive is useful for example for representing a list of valid opcodes.
+    """This primitive represents a list of static values, stepping through each one on mutation. You can tie a block
+    to a group primitive to specify that the block should cycle through all possible mutations for *each* value
+    within the group. The group primitive is useful for example for representing a list of valid opcodes.
 
-        @type  name:            str
-        @param name:            Name of group
-        @type  values:          list or bytes
-        @param values:          List of possible raw values this group can take.
+    :param values: List of possible raw values this group can take.
+    :type values: list of bytes
+    :param default_value: Value used when the element is not being fuzzed – should typically represent a valid value,
+        defaults to None
+    :type default_value: bytes, optional
+    :param encoding: String encoding, ex: utf_16_le for Microsoft Unicode, defaults to ascii
+    :type encoding: str, optional
+    :param name: Name, for referencing later. Names should always be provided, but if not, a default name will be given,
+        defaults to None
+    :type name: str, optional
+    """
 
-        @param default_value:   Specifying a value when fuzzing() is complete
-        @type  encoding:        str
-        @param encoding:        (Optional, def="ascii") String encoding, ex: utf_16_le for Microsoft Unicode.
-        """
+    def __init__(self, values, default_value=None, encoding="ascii", name=None, *args, **kwargs):
         assert len(values) > 0, "You can't have an empty value list for your group!"
         for val in values:
             assert isinstance(val, (six.binary_type, six.string_types)), "Value list may only contain string/byte types"

--- a/boofuzz/primitives/group.py
+++ b/boofuzz/primitives/group.py
@@ -9,10 +9,10 @@ class Group(BasePrimitive):
     within the group. The group primitive is useful for example for representing a list of valid opcodes.
 
     :param values: List of possible raw values this group can take.
-    :type values: list of bytes
+    :type values: list of bytes or list of str
     :param default_value: Value used when the element is not being fuzzed – should typically represent a valid value,
         defaults to None
-    :type default_value: bytes, optional
+    :type default_value: str, optional
     :param encoding: String encoding, ex: utf_16_le for Microsoft Unicode, defaults to ascii
     :type encoding: str, optional
     :param name: Name, for referencing later. Names should always be provided, but if not, a default name will be given,

--- a/boofuzz/primitives/group.py
+++ b/boofuzz/primitives/group.py
@@ -4,10 +4,15 @@ from .base_primitive import BasePrimitive
 
 
 class Group(BasePrimitive):
-    """This primitive represents a list of static values, stepping through each one on mutation. You can tie a block
+    """This primitive represents a list of static values, stepping through each one on mutation.
+
+    You can tie a block
     to a group primitive to specify that the block should cycle through all possible mutations for *each* value
     within the group. The group primitive is useful for example for representing a list of valid opcodes.
 
+    :param name: Name, for referencing later. Names should always be provided, but if not, a default name will be given,
+        defaults to None
+    :type name: str, optional
     :param values: List of possible raw values this group can take.
     :type values: list of bytes or list of str
     :param default_value: Value used when the element is not being fuzzed - should typically represent a valid value,
@@ -15,28 +20,25 @@ class Group(BasePrimitive):
     :type default_value: str, optional
     :param encoding: String encoding, ex: utf_16_le for Microsoft Unicode, defaults to ascii
     :type encoding: str, optional
-    :param name: Name, for referencing later. Names should always be provided, but if not, a default name will be given,
-        defaults to None
-    :type name: str, optional
+    :param fuzzable: Enable/disable fuzzing of this primitive, defaults to true
+    :type fuzzable: bool, optional
     """
 
-    def __init__(self, values, default_value=None, encoding="ascii", name=None, *args, **kwargs):
+    def __init__(self, name=None, values=None, default_value=None, encoding="ascii", *args, **kwargs):
         assert len(values) > 0, "You can't have an empty value list for your group!"
         for val in values:
             assert isinstance(val, (six.binary_type, six.string_types)), "Value list may only contain string/byte types"
         values = list(map(lambda value: value if isinstance(value, bytes) else value.encode(encoding=encoding), values))
-        if default_value is not None and not isinstance(default_value, bytes):
-            default_value = default_value.encode(encoding=encoding)
 
         if default_value is None:
             default_value = values[0]
 
+        default_value = default_value if isinstance(default_value, bytes) else default_value.encode(encoding=encoding)
+
         if default_value in values:
             values.remove(default_value)
 
-        default_value = default_value if isinstance(default_value, bytes) else default_value.encode(encoding=encoding)
-
-        super(Group, self).__init__(name, default_value, *args, **kwargs)
+        super(Group, self).__init__(name=name, default_value=default_value, *args, **kwargs)
 
         self.values = values
 

--- a/boofuzz/primitives/mirror.py
+++ b/boofuzz/primitives/mirror.py
@@ -20,16 +20,18 @@ def _may_recurse(f):
 class Mirror(BasePrimitive):
     """Primitive used to keep updated with another primitive.
 
+    :type name: str, optional
+    :param name: Name, for referencing later. Names should always be provided, but if not, a default name will be given,
+        defaults to None
     :type primitive_name: str
     :param primitive_name: Name of target primitive.
     :type request: boofuzz.Request
     :param request: Request this primitive belongs to.
-    :type name: str, optional
-    :param name: Name, for referencing later. Names should always be provided, but if not, a default name will be given,
-        defaults to None
+    :type fuzzable: bool, optional
+    :param fuzzable: Enable/disable fuzzing of this primitive, defaults to true
     """
 
-    def __init__(self, primitive_name, request, name=None, *args, **kwargs):
+    def __init__(self, name=None, primitive_name=None, request=None, *args, **kwargs):
         super(Mirror, self).__init__(name=name, default_value=None, *args, **kwargs)
 
         self._primitive_name = primitive_name

--- a/boofuzz/primitives/mirror.py
+++ b/boofuzz/primitives/mirror.py
@@ -18,16 +18,19 @@ def _may_recurse(f):
 
 
 class Mirror(BasePrimitive):
-    """
-    Primitive used to keep updated with another primitive.
+    """Primitive used to keep updated with another primitive.
 
-    Args:
-        primitive_name (str):   Name of target primitive.
-        request (s_request):    Request this primitive belongs to.
+    :type primitive_name: str
+    :param primitive_name: Name of target primitive.
+    :type request: boofuzz.Request
+    :param request: Request this primitive belongs to.
+    :type name: str, optional
+    :param name: Name, for referencing later. Names should always be provided, but if not, a default name will be given,
+        defaults to None
     """
 
-    def __init__(self, name, primitive_name, request, *args, **kwargs):
-        super(Mirror, self).__init__(name, default_value=None, *args, **kwargs)
+    def __init__(self, primitive_name, request, name=None, *args, **kwargs):
+        super(Mirror, self).__init__(name=name, default_value=None, *args, **kwargs)
 
         self._primitive_name = primitive_name
         self._request = request

--- a/boofuzz/primitives/qword.py
+++ b/boofuzz/primitives/qword.py
@@ -6,10 +6,11 @@ from boofuzz.primitives.bit_field import BitField
 
 
 class QWord(BitField):
-    def __init__(self, *args, **kwargs):
-        kwargs["width"] = 64
+    """The 8 byte sized bit field primitive. Inherits parameters from :class:`boofuzz.BitField`"""
 
-        super(QWord, self).__init__(*args, **kwargs)
+    def __init__(self, default_value, *args, **kwargs):
+        # Inject our width argument
+        super(QWord, self).__init__(default_value=default_value, width=64, *args, **kwargs)
 
     def encode(self, value, mutation_context):
         if not isinstance(value, (six.integer_types, list, tuple)):

--- a/boofuzz/primitives/qword.py
+++ b/boofuzz/primitives/qword.py
@@ -6,11 +6,32 @@ from boofuzz.primitives.bit_field import BitField
 
 
 class QWord(BitField):
-    """The 8 byte sized bit field primitive. Inherits parameters from :class:`boofuzz.BitField`"""
+    """The 8 byte sized bit field primitive.
 
-    def __init__(self, default_value, *args, **kwargs):
+    :type  name: str, optional
+    :param name: Name, for referencing later. Names should always be provided, but if not, a default name will be given,
+        defaults to None
+    :type  default_value: int, optional
+    :param default_value: Default integer value, defaults to 0
+    :type  max_num: int, optional
+    :param max_num: Maximum number to iterate up to, defaults to None
+    :type  endian: char, optional
+    :param endian: Endianness of the bit field (LITTLE_ENDIAN: <, BIG_ENDIAN: >), defaults to LITTLE_ENDIAN
+    :type  output_format: str, optional
+    :param output_format: Output format, "binary" or "ascii", defaults to binary
+    :type  signed: bool, optional
+    :param signed: Make size signed vs. unsigned (applicable only with format="ascii"), defaults to False
+    :type  full_range: bool, optional
+    :param full_range: If enabled the field mutates through *all* possible values, defaults to False
+    :type  fuzz_values: list, optional
+    :param fuzz_values: List of custom fuzz values to add to the normal mutations, defaults to None
+    :type  fuzzable: bool, optional
+    :param fuzzable: Enable/disable fuzzing of this primitive, defaults to true
+    """
+
+    def __init__(self, *args, **kwargs):
         # Inject our width argument
-        super(QWord, self).__init__(default_value=default_value, width=64, *args, **kwargs)
+        super(QWord, self).__init__(width=64, *args, **kwargs)
 
     def encode(self, value, mutation_context):
         if not isinstance(value, (six.integer_types, list, tuple)):

--- a/boofuzz/primitives/random_data.py
+++ b/boofuzz/primitives/random_data.py
@@ -9,28 +9,29 @@ from ..mutation import Mutation
 
 
 class RandomData(Fuzzable):
-    def __init__(self, name, value, min_length, max_length, max_mutations=25, step=None, *args, **kwargs):
-        """
-        Generate a random chunk of data while maintaining a copy of the original. A random length range
-        can be specified.
+    """Generate a random chunk of data while maintaining a copy of the original. A random length range can be specified.
 
-        For a static length, set min/max length to be the same.
+    For a static length, set min/max length to be the same.
 
-        @type  value:         str
-        @param value:         Original value
-        @type  min_length:    int
-        @param min_length:    Minimum length of random block
-        @type  max_length:    int
-        @param max_length:    Maximum length of random block
-        @type  max_mutations: int
-        @param max_mutations: (Optional, def=25) Number of mutations to make before reverting to default
-        @type  step:          int
-        @param step:          (Optional, def=None) If not null, step count between min and max reps, otherwise random
-        """
+    :param default_value: Value used when the element is not being fuzzed – should typically represent a valid value.
+    :type default_value: Any, optional
+    :param min_length: Minimum length of random block
+    :type min_length: int
+    :param max_length: Maximum length of random block
+    :type max_length: int
+    :param max_mutations: Number of mutations to make before reverting to default, defaults to 25
+    :type max_mutations: int, optional
+    :param step: If not None, step count between min and max reps, otherwise random, defaults to None
+    :type step: int, optional
+    :param name: Name, for referencing later. Names should always be provided, but if not, a default name will be given,
+        defaults to None
+    :type name: str, optional
+    """
 
-        super(RandomData, self).__init__(name, value, *args, **kwargs)
+    def __init__(self, default_value, min_length, max_length, max_mutations=25, step=None, name=None, *args, **kwargs):
+        super(RandomData, self).__init__(name=name, default_value=default_value, *args, **kwargs)
 
-        self._value = self._original_value = helpers.str_to_bytes(value)
+        self._value = self._original_value = helpers.str_to_bytes(default_value)
         self.min_length = min_length
         self.max_length = max_length
         self.max_mutations = max_mutations

--- a/boofuzz/primitives/random_data.py
+++ b/boofuzz/primitives/random_data.py
@@ -9,29 +9,35 @@ from ..mutation import Mutation
 
 
 class RandomData(Fuzzable):
-    """Generate a random chunk of data while maintaining a copy of the original. A random length range can be specified.
+    """Generate a random chunk of data while maintaining a copy of the original.
 
-    For a static length, set min/max length to be the same.
+    A random length range can be specified. For a static length, set min/max length to be the same.
 
-    :param default_value: Value used when the element is not being fuzzed - should typically represent a valid value.
+    :param name: Name, for referencing later. Names should always be provided, but if not, a default name will be given,
+        defaults to None
+    :type name: str, optional
+    :param default_value: Value used when the element is not being fuzzed - should typically represent a valid value,
+        defaults to None
     :type default_value: Any, optional
-    :param min_length: Minimum length of random block
-    :type min_length: int
-    :param max_length: Maximum length of random block
-    :type max_length: int
+    :param min_length: Minimum length of random block, defaults to 0
+    :type min_length: int, optional
+    :param max_length: Maximum length of random block, defaults to 1
+    :type max_length: int, optional
     :param max_mutations: Number of mutations to make before reverting to default, defaults to 25
     :type max_mutations: int, optional
     :param step: If not None, step count between min and max reps, otherwise random, defaults to None
     :type step: int, optional
-    :param name: Name, for referencing later. Names should always be provided, but if not, a default name will be given,
-        defaults to None
-    :type name: str, optional
+    :param fuzzable: Enable/disable fuzzing of this primitive, defaults to true
+    :type fuzzable: bool, optional
     """
 
-    def __init__(self, default_value, min_length, max_length, max_mutations=25, step=None, name=None, *args, **kwargs):
+    def __init__(
+        self, name=None, default_value="", min_length=0, max_length=1, max_mutations=25, step=None, *args, **kwargs
+    ):
+        default_value = helpers.str_to_bytes(default_value)
+
         super(RandomData, self).__init__(name=name, default_value=default_value, *args, **kwargs)
 
-        self._value = self._original_value = helpers.str_to_bytes(default_value)
         self.min_length = min_length
         self.max_length = max_length
         self.max_mutations = max_mutations

--- a/boofuzz/primitives/random_data.py
+++ b/boofuzz/primitives/random_data.py
@@ -13,7 +13,7 @@ class RandomData(Fuzzable):
 
     For a static length, set min/max length to be the same.
 
-    :param default_value: Value used when the element is not being fuzzed – should typically represent a valid value.
+    :param default_value: Value used when the element is not being fuzzed - should typically represent a valid value.
     :type default_value: Any, optional
     :param min_length: Minimum length of random block
     :type min_length: int

--- a/boofuzz/primitives/static.py
+++ b/boofuzz/primitives/static.py
@@ -3,8 +3,17 @@ from ..fuzzable import Fuzzable
 
 
 class Static(Fuzzable):
-    def __init__(self, *args, **kwargs):
-        super(Static, self).__init__(*args, **kwargs)
+    """Push a static value onto the current block stack.
+
+    :type default_value: Raw
+    :param default_value: Raw static data
+    :type name: str, optional
+    :param name: Name, for referencing later. Names should always be provided, but if not, a default name will be given,
+        defaults to None
+    """
+
+    def __init__(self, default_value, name=None, *args, **kwargs):
+        super(Static, self).__init__(name=name, default_value=default_value, fuzzable=False, *args, **kwargs)
 
     def encode(self, value, mutation_context):
         if value is None:

--- a/boofuzz/primitives/static.py
+++ b/boofuzz/primitives/static.py
@@ -5,14 +5,14 @@ from ..fuzzable import Fuzzable
 class Static(Fuzzable):
     """Push a static value onto the current block stack.
 
-    :type default_value: Raw
-    :param default_value: Raw static data
     :type name: str, optional
     :param name: Name, for referencing later. Names should always be provided, but if not, a default name will be given,
         defaults to None
+    :type default_value: Raw, optional
+    :param default_value: Raw static data
     """
 
-    def __init__(self, default_value, name=None, *args, **kwargs):
+    def __init__(self, name=None, default_value=None, *args, **kwargs):
         super(Static, self).__init__(name=name, default_value=default_value, fuzzable=False, *args, **kwargs)
 
     def encode(self, value, mutation_context):

--- a/boofuzz/primitives/string.py
+++ b/boofuzz/primitives/string.py
@@ -15,7 +15,7 @@ class String(Fuzzable):
     each instantiated primitive.
 
     :type default_value: str
-    :param default_value: Value used when the element is not being fuzzed – should typically represent a valid value.
+    :param default_value: Value used when the element is not being fuzzed - should typically represent a valid value.
     :type size: int, optional
     :param size: Static size of this field, leave -1 for dynamic, defaults to -1
     :type padding: chr, optional

--- a/boofuzz/primitives/string.py
+++ b/boofuzz/primitives/string.py
@@ -9,6 +9,26 @@ from ..fuzzable import Fuzzable
 
 
 class String(Fuzzable):
+    """Primitive that cycles through a library of "bad" strings. The class variable 'fuzz_library' contains a list of
+    smart fuzz values global across all instances. The 'this_library' variable contains fuzz values specific to
+    the instantiated primitive. This allows us to avoid copying the near ~70MB fuzz_library data structure across
+    each instantiated primitive.
+
+    :type default_value: str
+    :param default_value: Value used when the element is not being fuzzed – should typically represent a valid value.
+    :type size: int, optional
+    :param size: Static size of this field, leave -1 for dynamic, defaults to -1
+    :type padding: chr, optional
+    :param padding: Value to use as padding to fill static field size, defaults to "\\x00"
+    :type encoding: str, optional
+    :param encoding: String encoding, ex: utf_16_le for Microsoft Unicode, defaults to ascii
+    :type max_len: int, optional
+    :param max_len: Maximum string length, defaults to -1
+    :type name: str, optional
+    :param name: Name, for referencing later. Names should always be provided, but if not, a default name will be given,
+        defaults to None
+    """
+
     # store fuzz_library as a class variable to avoid copying the ~70MB structure across each instantiated primitive.
     _fuzz_library = [
         "",
@@ -168,26 +188,10 @@ class String(Fuzzable):
 
     _variable_mutation_multipliers = [2, 10, 100]
 
-    def __init__(self, name, default_value, size=-1, padding=b"\x00", encoding="ascii", max_len=-1, *args, **kwargs):
-        """
-        Primitive that cycles through a library of "bad" strings. The class variable 'fuzz_library' contains a list of
-        smart fuzz values global across all instances. The 'this_library' variable contains fuzz values specific to
-        the instantiated primitive. This allows us to avoid copying the near ~70MB fuzz_library data structure across
-        each instantiated primitive.
-
-        @type  value:    str
-        @param value:    Default string value
-        @type  size:     int
-        @param size:     (Optional, def=-1) Static size of this field, leave -1 for dynamic.
-        @type  padding:  chr
-        @param padding:  (Optional, def="\\x00") Value to use as padding to fill static field size.
-        @type  encoding: str
-        @param encoding: (Optional, def="ascii") String encoding, ex: utf_16_le for Microsoft Unicode.
-        @type  max_len:  int
-        @param max_len:  (Optional, def=-1) Maximum string length
-        """
-
-        super(String, self).__init__(name, default_value, *args, **kwargs)
+    def __init__(
+        self, default_value, size=-1, padding=b"\x00", encoding="ascii", max_len=-1, name=None, *args, **kwargs
+    ):
+        super(String, self).__init__(name=name, default_value=default_value, *args, **kwargs)
 
         self.size = size
         self.max_len = max_len

--- a/boofuzz/primitives/string.py
+++ b/boofuzz/primitives/string.py
@@ -9,11 +9,16 @@ from ..fuzzable import Fuzzable
 
 
 class String(Fuzzable):
-    """Primitive that cycles through a library of "bad" strings. The class variable 'fuzz_library' contains a list of
+    """Primitive that cycles through a library of "bad" strings.
+
+    The class variable 'fuzz_library' contains a list of
     smart fuzz values global across all instances. The 'this_library' variable contains fuzz values specific to
     the instantiated primitive. This allows us to avoid copying the near ~70MB fuzz_library data structure across
     each instantiated primitive.
 
+    :type name: str, optional
+    :param name: Name, for referencing later. Names should always be provided, but if not, a default name will be given,
+        defaults to None
     :type default_value: str
     :param default_value: Value used when the element is not being fuzzed - should typically represent a valid value.
     :type size: int, optional
@@ -24,9 +29,8 @@ class String(Fuzzable):
     :param encoding: String encoding, ex: utf_16_le for Microsoft Unicode, defaults to ascii
     :type max_len: int, optional
     :param max_len: Maximum string length, defaults to -1
-    :type name: str, optional
-    :param name: Name, for referencing later. Names should always be provided, but if not, a default name will be given,
-        defaults to None
+    :type fuzzable: bool, optional
+    :param fuzzable: Enable/disable fuzzing of this primitive, defaults to true
     """
 
     # store fuzz_library as a class variable to avoid copying the ~70MB structure across each instantiated primitive.
@@ -189,7 +193,7 @@ class String(Fuzzable):
     _variable_mutation_multipliers = [2, 10, 100]
 
     def __init__(
-        self, default_value, size=-1, padding=b"\x00", encoding="ascii", max_len=-1, name=None, *args, **kwargs
+        self, name=None, default_value="", size=-1, padding=b"\x00", encoding="ascii", max_len=-1, *args, **kwargs
     ):
         super(String, self).__init__(name=name, default_value=default_value, *args, **kwargs)
 

--- a/boofuzz/primitives/word.py
+++ b/boofuzz/primitives/word.py
@@ -6,10 +6,11 @@ from boofuzz.primitives.bit_field import BitField
 
 
 class Word(BitField):
-    def __init__(self, *args, **kwargs):
+    """The 2 byte sized bit field primitive. Inherits parameters from :class:`boofuzz.BitField`"""
+
+    def __init__(self, default_value, *args, **kwargs):
         # Inject our width argument
-        kwargs["width"] = 16
-        super(Word, self).__init__(*args, **kwargs)
+        super(Word, self).__init__(default_value=default_value, width=16, *args, **kwargs)
 
     def encode(self, value, mutation_context):
         if not isinstance(value, (six.integer_types, list, tuple)):

--- a/boofuzz/primitives/word.py
+++ b/boofuzz/primitives/word.py
@@ -6,11 +6,32 @@ from boofuzz.primitives.bit_field import BitField
 
 
 class Word(BitField):
-    """The 2 byte sized bit field primitive. Inherits parameters from :class:`boofuzz.BitField`"""
+    """The 2 byte sized bit field primitive.
 
-    def __init__(self, default_value, *args, **kwargs):
+    :type  name: str, optional
+    :param name: Name, for referencing later. Names should always be provided, but if not, a default name will be given,
+        defaults to None
+    :type  default_value: int, optional
+    :param default_value: Default integer value, defaults to 0
+    :type  max_num: int, optional
+    :param max_num: Maximum number to iterate up to, defaults to None
+    :type  endian: char, optional
+    :param endian: Endianness of the bit field (LITTLE_ENDIAN: <, BIG_ENDIAN: >), defaults to LITTLE_ENDIAN
+    :type  output_format: str, optional
+    :param output_format: Output format, "binary" or "ascii", defaults to binary
+    :type  signed: bool, optional
+    :param signed: Make size signed vs. unsigned (applicable only with format="ascii"), defaults to False
+    :type  full_range: bool, optional
+    :param full_range: If enabled the field mutates through *all* possible values, defaults to False
+    :type  fuzz_values: list, optional
+    :param fuzz_values: List of custom fuzz values to add to the normal mutations, defaults to None
+    :type  fuzzable: bool, optional
+    :param fuzzable: Enable/disable fuzzing of this primitive, defaults to true
+    """
+
+    def __init__(self, *args, **kwargs):
         # Inject our width argument
-        super(Word, self).__init__(default_value=default_value, width=16, *args, **kwargs)
+        super(Word, self).__init__(width=16, *args, **kwargs)
 
     def encode(self, value, mutation_context):
         if not isinstance(value, (six.integer_types, list, tuple)):

--- a/boofuzz/protocol_session_reference.py
+++ b/boofuzz/protocol_session_reference.py
@@ -12,7 +12,7 @@ class ProtocolSessionReference(object):
         name (str): Refers to a test case session key. Must be set in the
             :class:`ProtocolSession <boofuzz.ProtocolSession>` by the time the value is required in the protocol
             definition. See :class:`Session <boofuzz.Session>`.
-        default_value: The default default value, used if the element must be rendered outside the context of a test
+        default_value: The default value, used if the element must be rendered outside the context of a test
             case, or sometimes for generating mutations.
     """
 

--- a/docs/user/protocol-definition.rst
+++ b/docs/user/protocol-definition.rst
@@ -62,6 +62,7 @@ Primitives
 .. autofunction:: boofuzz.Static
 .. autofunction:: boofuzz.String
 .. autofunction:: boofuzz.FromFile
+.. autofunction:: boofuzz.Mirror
 .. autofunction:: boofuzz.BitField
 .. autofunction:: boofuzz.Byte
 .. autofunction:: boofuzz.Bytes

--- a/examples/ftp_simple.py
+++ b/examples/ftp_simple.py
@@ -20,31 +20,31 @@ def define_proto(session):
     # disable Black formatting to keep custom indentation
     # fmt: off
     user = Request("user", children=(
-        String("key", "USER"),
-        Delim("space", " "),
-        String("val", "anonymous"),
-        Static("end", "\r\n"),
+        String(name="key", default_value="USER"),
+        Delim(name="space", default_value=" "),
+        String(name="val", default_value="anonymous"),
+        Static(name="end", default_value="\r\n"),
     ))
 
     passw = Request("pass", children=(
-        String("key", "PASS"),
-        Delim("space", " "),
-        String("val", "james"),
-        Static("end", "\r\n"),
+        String(name="key", default_value="PASS"),
+        Delim(name="space", default_value=" "),
+        String(name="val", default_value="james"),
+        Static(name="end", default_value="\r\n"),
     ))
 
     stor = Request("stor", children=(
-        String("key", "STOR"),
-        Delim("space", " "),
-        String("val", "AAAA"),
-        Static("end", "\r\n"),
+        String(name="key", default_value="STOR"),
+        Delim(name="space", default_value=" "),
+        String(name="val", default_value="AAAA"),
+        Static(name="end", default_value="\r\n"),
     ))
 
     retr = Request("retr", children=(
-        String("key", "RETR"),
-        Delim("space", " "),
-        String("val", "AAAA"),
-        Static("end", "\r\n"),
+        String(name="key", default_value="RETR"),
+        Delim(name="space", default_value=" "),
+        String(name="val", default_value="AAAA"),
+        Static(name="end", default_value="\r\n"),
     ))
     # fmt: on
 

--- a/examples/http_simple.py
+++ b/examples/http_simple.py
@@ -21,20 +21,20 @@ def define_proto(session):
     # fmt: off
     req = Request("HTTP-Request", children=(
         Block("Request-Line", children=(
-            Group("Method", values=["GET", "HEAD", "POST", "PUT", "DELETE", "CONNECT", "OPTIONS", "TRACE"]),
-            Delim("space-1", " "),
-            String("URI", "/index.html"),
-            Delim("space-2", " "),
-            String("HTTP-Version", "HTTP/1.1"),
-            Static("CRLF", "\r\n"),
+            Group(name="Method", values=["GET", "HEAD", "POST", "PUT", "DELETE", "CONNECT", "OPTIONS", "TRACE"]),
+            Delim(name="space-1", default_value=" "),
+            String(name="URI", default_value="/index.html"),
+            Delim(name="space-2", default_value=" "),
+            String(name="HTTP-Version", default_value="HTTP/1.1"),
+            Static(name="CRLF", default_value="\r\n"),
         )),
         Block("Host-Line", children=(
-            String("Host-Key", "Host:"),
-            Delim("space", " "),
-            String("Host-Value", "example.com"),
-            Static("CRLF", "\r\n"),
+            String(name="Host-Key", default_value="Host:"),
+            Delim(name="space", default_value=" "),
+            String(name="Host-Value", default_value="example.com"),
+            Static(name="CRLF", default_value="\r\n"),
         )),
-        Static("CRLF", "\r\n"),
+        Static(name="CRLF", default_value="\r\n"),
     ))
     # fmt: on
 

--- a/unit_tests/test_bytes.py
+++ b/unit_tests/test_bytes.py
@@ -16,17 +16,17 @@ class TestBytes(unittest.TestCase):
     def _given_bytes(self):
         self.default_value = b"ABCDEFGH"
         self.default_default_value = b"\x00" * len(self.default_value)
-        return Bytes(name=b"boofuzz-unit-test-name", default_value=self.default_value)
+        return Bytes(name="boofuzz-unit-test-name", default_value=self.default_value)
 
     def _given_bytes_max_len(self, max_len):
         self.default_value = b"ABCDEFGH"
         self.default_default_value = b"\x00" * len(self.default_value)
-        return Bytes(name=b"boofuzz-unit-test-name", default_value=self.default_value, max_len=max_len)
+        return Bytes(name="boofuzz-unit-test-name", default_value=self.default_value, max_len=max_len)
 
     def _given_bytes_size(self, size, padding):
         self.default_value = b"ABCDEFGH"
         self.default_default_value = b"\x00" * len(self.default_value)
-        return Bytes(name=b"boofuzz-unit-test-name", default_value=self.default_value, size=size, padding=padding)
+        return Bytes(name="boofuzz-unit-test-name", default_value=self.default_value, size=size, padding=padding)
 
     def test_mutations(self):
         uut = self._given_bytes()

--- a/unit_tests/test_bytes.py
+++ b/unit_tests/test_bytes.py
@@ -16,17 +16,17 @@ class TestBytes(unittest.TestCase):
     def _given_bytes(self):
         self.default_value = b"ABCDEFGH"
         self.default_default_value = b"\x00" * len(self.default_value)
-        return Bytes("boofuzz-unit-test-name", self.default_value)
+        return Bytes(name=b"boofuzz-unit-test-name", default_value=self.default_value)
 
     def _given_bytes_max_len(self, max_len):
         self.default_value = b"ABCDEFGH"
         self.default_default_value = b"\x00" * len(self.default_value)
-        return Bytes("boofuzz-unit-test-name", self.default_value, max_len=max_len)
+        return Bytes(name=b"boofuzz-unit-test-name", default_value=self.default_value, max_len=max_len)
 
     def _given_bytes_size(self, size, padding):
         self.default_value = b"ABCDEFGH"
         self.default_default_value = b"\x00" * len(self.default_value)
-        return Bytes("boofuzz-unit-test-name", self.default_value, size=size, padding=padding)
+        return Bytes(name=b"boofuzz-unit-test-name", default_value=self.default_value, size=size, padding=padding)
 
     def test_mutations(self):
         uut = self._given_bytes()

--- a/unit_tests/test_string.py
+++ b/unit_tests/test_string.py
@@ -16,17 +16,17 @@ class TestString(unittest.TestCase):
     def _given_string(self):
         self.default_value = "ABCDEFGH"
         self.default_default_value = "\x00" * len(self.default_value)
-        return String("boofuzz-unit-test-name", self.default_value)
+        return String(name="boofuzz-unit-test-name", default_value=self.default_value)
 
     def _given_bytes_max_len(self, max_len):
-        self.default_value = "ABCDEFGH"
+        self.default_value = b"ABCDEFGH"
         self.default_default_value = "\x00" * len(self.default_value)
-        return Bytes("boofuzz-unit-test-name", self.default_value, max_len=max_len)
+        return Bytes(name=b"boofuzz-unit-test-name", default_value=self.default_value, max_len=max_len)
 
     def _given_bytes_size(self, size, padding):
-        self.default_value = "ABCDEFGH"
+        self.default_value = b"ABCDEFGH"
         self.default_default_value = "\x00" * len(self.default_value)
-        return Bytes("boofuzz-unit-test-name", self.default_value, size=size, padding=padding)
+        return Bytes(name=b"boofuzz-unit-test-name", default_value=self.default_value, size=size, padding=padding)
 
     def test_mutations(self):
         uut = self._given_string()

--- a/unit_tests/test_string.py
+++ b/unit_tests/test_string.py
@@ -21,12 +21,12 @@ class TestString(unittest.TestCase):
     def _given_bytes_max_len(self, max_len):
         self.default_value = b"ABCDEFGH"
         self.default_default_value = "\x00" * len(self.default_value)
-        return Bytes(name=b"boofuzz-unit-test-name", default_value=self.default_value, max_len=max_len)
+        return Bytes(name="boofuzz-unit-test-name", default_value=self.default_value, max_len=max_len)
 
     def _given_bytes_size(self, size, padding):
         self.default_value = b"ABCDEFGH"
         self.default_default_value = "\x00" * len(self.default_value)
-        return Bytes(name=b"boofuzz-unit-test-name", default_value=self.default_value, size=size, padding=padding)
+        return Bytes(name="boofuzz-unit-test-name", default_value=self.default_value, size=size, padding=padding)
 
     def test_mutations(self):
         uut = self._given_string()


### PR DESCRIPTION
I noticed that parts of the new protocol definition documentation is incomplete, so I completely reworked that part.
The static protocol definition documentation remains mostly the same, to prevent breaking changes.

There's one thing I'm uncertain about: Should each primitives docstring and signature contain the `name` and `fuzzable` parameter?
Technically this is not needed because we pass kwargs down to `Fuzzable`, however I think it would make it more clear for the user which parameter a primitive/block can take.

So on top of this change I'd suggest adding the `fuzzable` parameter after `name`, just like we have it on most static definitions.