### PR TITLE
Correctly truncate and deduplicate strings

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,6 +28,9 @@ Fixes
 - Network monitor: fixed data_bytes calculation and PcapThread synchronization
 - Fixed a crash when using the network monitor
 - Session can now be "quiet" by passing an empty list of loggers
+- Correctly truncate values of the string primitive when max_len or size is set.
+- The string primitive will no longer generate duplicates when max_len or size is set.
+- Greatly improved string to bytes conversion speed.
 
 v0.2.1
 ------

--- a/boofuzz/__init__.py
+++ b/boofuzz/__init__.py
@@ -724,6 +724,7 @@ def s_string(value="", size=None, padding=b"\x00", encoding="ascii", fuzzable=Tr
     :type  name:     str
     :param name:     (Optional, def=None) Specifying a name gives you direct access to a primitive
     """
+    # support old interface where default was -1 instead of None
     if size == -1:
         size = None
     if max_len == -1:

--- a/boofuzz/__init__.py
+++ b/boofuzz/__init__.py
@@ -649,7 +649,7 @@ def s_random(value="", min_length=0, max_length=1, num_mutations=25, fuzzable=Tr
     Generate a random chunk of data while maintaining a copy of the original. A random length range can be specified.
     For a static length, set min/max length to be the same.
 
-    :type  value:         Raw
+    :type  value:         str or bytes
     :param value:         (Optional, def="") Original value
     :type  min_length:    int
     :param min_length:    (Optional, def=0) Minimum length of random block
@@ -705,25 +705,29 @@ def s_mirror(primitive_name=None, name=None):
     blocks.CURRENT.push(Mirror(name=name, primitive_name=primitive_name, request=blocks.CURRENT))
 
 
-def s_string(value="", size=-1, padding=b"\x00", encoding="ascii", fuzzable=True, max_len=-1, name=None):
+def s_string(value="", size=None, padding=b"\x00", encoding="ascii", fuzzable=True, max_len=None, name=None):
     """
     Push a string onto the current block stack.
 
     :type  value:    str
     :param value:    (Optional, def="")Default string value
     :type  size:     int
-    :param size:     (Optional, def=-1) Static size of this field, leave -1 for dynamic.
+    :param size:     (Optional, def=None) Static size of this field, leave None for dynamic.
     :type  padding:  Character
     :param padding:  (Optional, def="\\x00") Value to use as padding to fill static field size.
     :type  encoding: str
-    :param encoding: (Optonal, def="ascii") String encoding, ex: utf_16_le for Microsoft Unicode.
+    :param encoding: (Optional, def="ascii") String encoding, ex: utf_16_le for Microsoft Unicode.
     :type  fuzzable: bool
     :param fuzzable: (Optional, def=True) Enable/disable fuzzing of this primitive
     :type  max_len:  int
-    :param max_len:  (Optional, def=-1) Maximum string length
+    :param max_len:  (Optional, def=None) Maximum string length
     :type  name:     str
     :param name:     (Optional, def=None) Specifying a name gives you direct access to a primitive
     """
+    if size == -1:
+        size = None
+    if max_len == -1:
+        max_len = None
 
     blocks.CURRENT.push(
         String(

--- a/boofuzz/fuzzable.py
+++ b/boofuzz/fuzzable.py
@@ -25,12 +25,12 @@ class Fuzzable(object):
     :type name: str, optional
     :param name: Name, for referencing later. Names should always be provided, but if not, a default name will be given,
         defaults to None
-    :type default_value: Any
+    :type default_value: Any, optional
     :param default_value: Value used when the element is not being fuzzed - should typically represent a valid value.
         Can be a static value, or a ReferenceValueTestCaseSession, defaults to None
-    :type fuzzable: bool
+    :type fuzzable: bool, optional
     :param fuzzable: Enable fuzzing of this primitive, defaults to True
-    :type fuzz_values: list
+    :type fuzz_values: list, optional
     :param fuzz_values: List of custom fuzz values to add to the normal mutations, defaults to None
     """
 
@@ -62,9 +62,6 @@ class Fuzzable(object):
 
         :rtype: str
         """
-        # if self._name is None:
-        #     Fuzzable.name_counter += 1
-        #     self._name = "{0}{1}".format(type(self).__name__, Fuzzable.name_counter)
         return self._name
 
     @property

--- a/boofuzz/helpers.py
+++ b/boofuzz/helpers.py
@@ -439,11 +439,5 @@ def get_boofuzz_version(boofuzz_class):
     return "v-.-.-"
 
 
-def str_to_bytes(value):
-    result = value
-    # if python2, str is already bytes compatible
-    if six.PY3:
-        if isinstance(value, six.text_type):
-            temp = [bytes([ord(i)]) for i in value]
-            result = b"".join(temp)
-    return result
+def str_to_bytes(value, encoding="utf-8", errors="replace"):
+    return six.ensure_binary(value, encoding=encoding, errors=errors)

--- a/boofuzz/primitives/random_data.py
+++ b/boofuzz/primitives/random_data.py
@@ -18,7 +18,7 @@ class RandomData(Fuzzable):
     :type name: str, optional
     :param default_value: Value used when the element is not being fuzzed - should typically represent a valid value,
         defaults to None
-    :type default_value: Any, optional
+    :type default_value: str or bytes, optional
     :param min_length: Minimum length of random block, defaults to 0
     :type min_length: int, optional
     :param max_length: Maximum length of random block, defaults to 1

--- a/boofuzz/primitives/string.py
+++ b/boofuzz/primitives/string.py
@@ -205,12 +205,15 @@ class String(Fuzzable):
         self._static_num_mutations = None
         self.random_indices = {}
 
-        random.seed(0)
+        random.seed(0)  # We want constant random numbers to generate reproducible test cases
+        previous_length = 0
+        # For every length add a random number of random indices to the random_indices dict. Prevent duplicates by
+        # adding only indices in between previous_length and current length.
         for length in self._long_string_lengths:
-            self.random_indices[length] = []
-            for _ in range(random.randint(1, 10)):  # Number of null bytes to insert (random)
-                loc = random.randint(0, length)  # Location of random byte
-                self.random_indices[length].append(loc)
+            self.random_indices[length] = random.sample(
+                range(previous_length, length), random.randint(1, self._long_string_lengths[0])
+            )
+            previous_length = length
 
     def _yield_long_strings(self, sequences):
         """
@@ -245,8 +248,7 @@ class String(Fuzzable):
             if self.max_len is None or size <= self.max_len:
                 s = "D" * size
                 for loc in self.random_indices[size]:
-                    s = s[:loc] + "\x00" + s[loc + 1 :]  # Replace character at loc with terminator
-                yield s
+                    yield s[:loc] + "\x00" + s[loc + 1:]  # Replace character at loc with terminator
             else:
                 break
 

--- a/boofuzz/primitives/string.py
+++ b/boofuzz/primitives/string.py
@@ -248,7 +248,7 @@ class String(Fuzzable):
             if self.max_len is None or size <= self.max_len:
                 s = "D" * size
                 for loc in self.random_indices[size]:
-                    yield s[:loc] + "\x00" + s[loc + 1:]  # Replace character at loc with terminator
+                    yield s[:loc] + "\x00" + s[loc + 1 :]  # Replace character at loc with terminator
             else:
                 break
 

--- a/boofuzz/primitives/string.py
+++ b/boofuzz/primitives/string.py
@@ -1,11 +1,16 @@
+from __future__ import division
+
+import math
 import random
 
 import six
 from future.moves import itertools
-from past.builtins import range
+from future.standard_library import install_aliases
+from six.moves import range
 
-from .. import helpers
 from ..fuzzable import Fuzzable
+
+install_aliases()
 
 
 class String(Fuzzable):
@@ -22,137 +27,129 @@ class String(Fuzzable):
     :type default_value: str
     :param default_value: Value used when the element is not being fuzzed - should typically represent a valid value.
     :type size: int, optional
-    :param size: Static size of this field, leave -1 for dynamic, defaults to -1
+    :param size: Static size of this field, leave None for dynamic, defaults to None
     :type padding: chr, optional
     :param padding: Value to use as padding to fill static field size, defaults to "\\x00"
     :type encoding: str, optional
     :param encoding: String encoding, ex: utf_16_le for Microsoft Unicode, defaults to ascii
     :type max_len: int, optional
-    :param max_len: Maximum string length, defaults to -1
+    :param max_len: Maximum string length, defaults to None
     :type fuzzable: bool, optional
     :param fuzzable: Enable/disable fuzzing of this primitive, defaults to true
     """
 
     # store fuzz_library as a class variable to avoid copying the ~70MB structure across each instantiated primitive.
+    # Has to be sorted to avoid duplicates
     _fuzz_library = [
-        "",
-        # strings ripped from spike (and some others I added)
-        "/.:/" + "A" * 5000 + "\x00\x00",
-        "/.../" + "B" * 5000 + "\x00\x00",
-        "/.../.../.../.../.../.../.../.../.../.../",
-        "/../../../../../../../../../../../../etc/passwd",
-        "/../../../../../../../../../../../../boot.ini",
-        "..:..:..:..:..:..:..:..:..:..:..:..:..:",
-        "\\\\*",
-        "\\\\?\\",
-        "/\\" * 5000,
-        "/." * 5000,
         "!@#$%%^#$%#$@#$%$$@#$%^^**(()",
+        "",  # strings ripped from spike (and some others I added)
+        "$(reboot)",
+        "$;reboot",
+        "%00",
+        "%00/",
         "%01%02%03%04%0a%0d%0aADSF",
         "%01%02%03@%04%0a%0d%0aADSF",
-        "\x01\x02\x03\x04",
-        "/%00/",
-        "%00/",
-        "%00",
-        "%u0000",
+        "%0a reboot %0a",
+        "%0Areboot",
+        "%0Areboot%0A",
+        "%0DCMD=$'reboot';$CMD",
+        '%0DCMD=$"reboot";$CMD',
+        "%0Dreboot",
+        "%0Dreboot%0D",
         "%\xfe\xf0%\x00\xff",
         "%\xfe\xf0%\x01\xff" * 20,
-        # format strings.
-        "%n" * 100,
+        "%n" * 100,  # format strings.
         "%n" * 500,
-        '"%n"' * 500,
         "%s" * 100,
         "%s" * 500,
-        '"%s"' * 500,
-        # command injection.
-        "|touch /tmp/SULLEY",
-        ";touch /tmp/SULLEY;",
-        "|notepad",
-        ";notepad;",
-        "\nnotepad\n",
-        "|reboot",
-        ";reboot;",
-        "\nreboot\n",
-        # fuzzdb command injection
-        "a)|reboot;",
-        "CMD=$'reboot';$CMD",
-        "a;reboot",
-        "a)|reboot",
-        "|reboot;",
-        "'reboot'",
-        '^CMD=$"reboot";$CMD',
-        "`reboot`",
-        "%0DCMD=$'reboot';$CMD",
-        "/index.html|reboot|",
-        "%0a reboot %0a",
-        "|reboot|",
-        "||reboot;",
-        ";reboot/n",
-        "id",
-        ";id",
-        "a;reboot|",
-        "&reboot&",
-        "%0Areboot",
-        "a);reboot",
-        "$;reboot",
-        '&CMD=$"reboot";$CMD',
-        '&&CMD=$"reboot";$CMD',
-        ";reboot",
-        "id;",
-        ";reboot;",
-        "&CMD=$'reboot';$CMD",
+        "%u0000",
         "& reboot &",
-        "; reboot",
-        "&&CMD=$'reboot';$CMD",
-        "reboot",
-        "^CMD=$'reboot';$CMD",
-        ";CMD=$'reboot';$CMD",
-        "|reboot",
-        "<reboot;",
-        "FAIL||reboot",
-        "a);reboot|",
-        '%0DCMD=$"reboot";$CMD',
-        "reboot|",
-        "%0Areboot%0A",
-        "a;reboot;",
-        'CMD=$"reboot";$CMD',
-        "&&reboot",
-        "||reboot|",
-        "&&reboot&&",
-        "^reboot",
-        ";|reboot|",
-        "|CMD=$'reboot';$CMD",
-        "|nid",
-        "&reboot",
-        "a|reboot",
-        "<reboot%0A",
-        'FAIL||CMD=$"reboot";$CMD',
-        "$(reboot)",
-        "<reboot%0D",
-        ";reboot|",
-        "id|",
-        "%0Dreboot",
-        "%0Areboot%0A",
-        "%0Dreboot%0D",
-        ";system('reboot')",
-        '|CMD=$"reboot";$CMD',
-        ';CMD=$"reboot";$CMD',
-        "<reboot",
-        "a);reboot;",
         "& reboot",
-        "| reboot",
-        "FAIL||CMD=$'reboot';$CMD",
+        "&&CMD=$'reboot';$CMD",
+        '&&CMD=$"reboot";$CMD',
+        "&&reboot",
+        "&&reboot&&",
+        "&CMD=$'reboot';$CMD",
+        '&CMD=$"reboot";$CMD',
+        "&reboot",
+        "&reboot&",
+        "'reboot'",
+        "..:..:..:..:..:..:..:..:..:..:..:..:..:",
+        "/%00/",
+        "/." * 5000,
+        "/.../" + "B" * 5000 + "\x00\x00",
+        "/.../.../.../.../.../.../.../.../.../.../",
+        "/../../../../../../../../../../../../boot.ini",
+        "/../../../../../../../../../../../../etc/passwd",
+        "/.:/" + "A" * 5000 + "\x00\x00",
+        "/\\" * 5000,
+        "/index.html|reboot|",
+        "; reboot",
+        ";CMD=$'reboot';$CMD",
+        ';CMD=$"reboot";$CMD',
+        ";id",
+        ";notepad;",
+        ";reboot",
+        ";reboot/n",
+        ";reboot;",
+        ";reboot|",
+        ";system('reboot')",
+        ";touch /tmp/SULLEY;",
+        ";|reboot|",
         '<!--#exec cmd="reboot"-->',
-        "reboot;",
-        # some binary strings.
-        "\xde\xad\xbe\xef",
+        "<>" * 500,  # sendmail crackaddr (http://lsd-pl.net/other/sendmail.txt)
+        "<reboot",
+        "<reboot%0A",
+        "<reboot%0D",
+        "<reboot;",
+        '"%n"' * 500,
+        '"%s"' * 500,
+        "\\\\*",
+        "\\\\?\\",
+        "\nnotepad\n",
+        "\nreboot\n",
+        "\r\n" * 100,  # miscellaneous.
+        "\x01\x02\x03\x04",
         "\xde\xad\xbe\xef" * 10,
         "\xde\xad\xbe\xef" * 100,
         "\xde\xad\xbe\xef" * 1000,
         "\xde\xad\xbe\xef" * 10000,
-        # miscellaneous.
-        "\r\n" * 100,
-        "<>" * 500,  # sendmail crackaddr (http://lsd-pl.net/other/sendmail.txt)
+        "\xde\xad\xbe\xef",  # some binary strings.
+        "^CMD=$'reboot';$CMD",
+        '^CMD=$"reboot";$CMD',
+        "^reboot",
+        "`reboot`",
+        "a);reboot",
+        "a);reboot;",
+        "a);reboot|",
+        "a)|reboot",
+        "a)|reboot;",  # fuzzdb command injection
+        "a;reboot",
+        "a;reboot;",
+        "a;reboot|",
+        "a|reboot",
+        "CMD=$'reboot';$CMD",
+        'CMD=$"reboot";$CMD',
+        "FAIL||CMD=$'reboot';$CMD",
+        'FAIL||CMD=$"reboot";$CMD',
+        "FAIL||reboot",
+        "id",
+        "id;",
+        "id|",
+        "reboot",
+        "reboot;",
+        "reboot|",
+        "| reboot",
+        "|CMD=$'reboot';$CMD",
+        '|CMD=$"reboot";$CMD',
+        "|nid",
+        "|notepad",
+        "|reboot",
+        "|reboot;",
+        "|reboot|",
+        "|touch /tmp/SULLEY",  # command injection.
+        "||reboot;",
+        "||reboot|",
     ]
 
     long_string_seeds = [
@@ -186,24 +183,26 @@ class String(Fuzzable):
         "\xFF",  # expands to 4 characters under utf1
     ]
 
-    _long_string_lengths = [128, 256, 512, 1024, 2048, 4096, 32768, 0xFFFF]
+    _long_string_lengths = [8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 32768, 0xFFFF]
     _long_string_deltas = [-2, -1, 0, 1, 2]
-    _extra_long_string_lengths = [5000, 10000, 20000, 99999, 100000, 500000, 1000000]
+    _extra_long_string_lengths = [99999, 100000, 500000, 1000000]
 
     _variable_mutation_multipliers = [2, 10, 100]
 
     def __init__(
-        self, name=None, default_value="", size=-1, padding=b"\x00", encoding="ascii", max_len=-1, *args, **kwargs
+        self, name=None, default_value="", size=None, padding=b"\x00", encoding="ascii", max_len=None, *args, **kwargs
     ):
         super(String, self).__init__(name=name, default_value=default_value, *args, **kwargs)
 
         self.size = size
         self.max_len = max_len
-        if self.size > -1:
+        if self.size is not None:
             self.max_len = self.size
-        self.padding = padding
         self.encoding = encoding
-
+        self.padding = padding
+        if isinstance(padding, six.text_type):
+            self.padding = self.padding.encode(self.encoding)
+        self._static_num_mutations = None
         self.random_indices = {}
 
         random.seed(0)
@@ -223,24 +222,43 @@ class String(Fuzzable):
         for sequence in sequences:
             for size in self._long_string_lengths:
                 for delta in self._long_string_deltas:
-                    yield sequence * (size + delta)
+                    if self.max_len is None or size + delta <= self.max_len:
+                        data = sequence * math.ceil((size + delta) / len(sequence))
+                        yield data[: size + delta]
+
+            for size in self._extra_long_string_lengths:
+                if self.max_len is None or size <= self.max_len:
+                    data = sequence * math.ceil(size / len(sequence))
+                    yield data[:size]
+
+            if self.max_len is not None and (
+                self.max_len < min(self._long_string_lengths[0], self._extra_long_string_lengths[0])
+                or self.max_len
+                > max(self._long_string_lengths[-1] + self._long_string_deltas[-1], self._extra_long_string_lengths[-1])
+            ):
+                data = sequence * math.ceil(self.max_len / len(sequence))
+                yield data[: self.max_len]
 
         for size in self._long_string_lengths:
-            s = "D" * size
-            for loc in self.random_indices[size]:
-                s = s[:loc] + "\x00" + s[loc:]
-                yield s
-
-        for sequence in sequences:
-            for size in self._extra_long_string_lengths:
-                yield sequence * size
+            if self.max_len is None or size <= self.max_len + 1:
+                s = "D" * size
+                for loc in self.random_indices[size]:
+                    s = s[:loc] + "\x00" + s[loc:]  # Do we really have to insert a char or can we replace it?
+                    yield s
 
     def _yield_variable_mutations(self, default_value):
         for length in self._variable_mutation_multipliers:
-            yield default_value * length
-        # doesn't make sense while we're yielding strings:
-        # for length in self._variable_mutation_multipliers:
-        #     yield default_value * length + b"\xfe"
+            value = default_value * length
+            if value not in self._fuzz_library:
+                yield value
+                if self.max_len is not None and self.max_len <= len(value):
+                    break
+
+    def _adjust_mutation_for_size(self, fuzz_value):
+        if self.max_len is not None and self.max_len < len(fuzz_value):
+            return fuzz_value[: self.max_len]
+        else:
+            return fuzz_value
 
     def mutations(self, default_value):
         """
@@ -253,24 +271,27 @@ class String(Fuzzable):
         Yields:
             str: Mutations
         """
+        last_val = None
 
         for val in itertools.chain(
             self._fuzz_library,
             self._yield_variable_mutations(default_value),
             self._yield_long_strings(self.long_string_seeds),
         ):
-            if self.max_len < 0 or len(val) <= self.max_len:
-                yield val
+            current_val = self._adjust_mutation_for_size(val)
+            if last_val == current_val:
+                continue
+            last_val = current_val
+            yield current_val
 
         # TODO: Add easy and sane string injection from external file/s
 
-    def encode(self, value, mutation_context):
-        if isinstance(value, six.text_type):
-            value = helpers.str_to_bytes(value)
+    def encode(self, value, mutation_context=None):
+        value = six.ensure_binary(value, self.encoding, "replace")
         # pad undersized library items.
-        if len(value) < self.size:
+        if self.size is not None and len(value) < self.size:
             value += self.padding * (self.size - len(value))
-        return helpers.str_to_bytes(value)
+        return value
 
     def num_mutations(self, default_value):
         """
@@ -282,12 +303,8 @@ class String(Fuzzable):
         Returns:
             int: Number of mutated forms this primitive can take
         """
-        return sum(
-            (
-                len(self._fuzz_library),
-                len(self._variable_mutation_multipliers),
-                (len(self.long_string_seeds) * len(self._long_string_lengths) * len(self._long_string_deltas)),
-                sum((len(indices) for _, indices in self.random_indices.items())),
-                (len(self._extra_long_string_lengths) * len(self.long_string_seeds)),
-            )
-        )
+        variable_num_mutations = sum(1 for _ in self._yield_variable_mutations(default_value=default_value))
+        if self._static_num_mutations is None:
+            #  Counting the number of mutations with default value "" results in 0 variable_num_mutations 3 * "" = ""
+            self._static_num_mutations = sum(1 for _ in self.mutations(default_value=""))
+        return self._static_num_mutations + variable_num_mutations

--- a/boofuzz/primitives/string.py
+++ b/boofuzz/primitives/string.py
@@ -190,7 +190,7 @@ class String(Fuzzable):
     _variable_mutation_multipliers = [2, 10, 100]
 
     def __init__(
-        self, name=None, default_value="", size=None, padding=b"\x00", encoding="ascii", max_len=None, *args, **kwargs
+        self, name=None, default_value="", size=None, padding=b"\x00", encoding="utf-8", max_len=None, *args, **kwargs
     ):
         super(String, self).__init__(name=name, default_value=default_value, *args, **kwargs)
 
@@ -209,7 +209,7 @@ class String(Fuzzable):
         for length in self._long_string_lengths:
             self.random_indices[length] = []
             for _ in range(random.randint(1, 10)):  # Number of null bytes to insert (random)
-                loc = random.randint(1, length)  # Location of random byte
+                loc = random.randint(0, length)  # Location of random byte
                 self.random_indices[length].append(loc)
 
     def _yield_long_strings(self, sequences):
@@ -242,11 +242,11 @@ class String(Fuzzable):
                 yield data
 
         for size in self._long_string_lengths:
-            if self.max_len is None or size <= self.max_len + 1:
+            if self.max_len is None or size <= self.max_len:
                 s = "D" * size
                 for loc in self.random_indices[size]:
-                    s = s[:loc] + "\x00" + s[loc:]  # Do we really have to insert a char or can we replace it?
-                    yield s
+                    s = s[:loc] + "\x00" + s[loc + 1 :]  # Replace character at loc with terminator
+                yield s
             else:
                 break
 

--- a/unit_tests/test_blocks.py
+++ b/unit_tests/test_blocks.py
@@ -33,7 +33,7 @@ class TestBlocks(DebuggableTestCase):
             s_word(0xDEAD, name="word")
             s_dword(0xDEADBEEF, name="dword")
             s_qword(0xDEADBEEFDEADBEEF, name="qword")
-            s_random(0, 5, 10, 100, name="random")
+            s_random(b"\x00", 5, 10, 100, name="random")
             s_block_end()
 
         req1 = s_get("UNIT TEST 1")
@@ -88,7 +88,7 @@ class TestBlocks(DebuggableTestCase):
             s_word(0xDEAD, name="word")
             s_dword(0xDEADBEEF, name="dword")
             s_qword(0xDEADBEEFDEADBEEF, name="qword")
-            s_random(0, 5, 10, 100, name="random")
+            s_random(b"\x00", 5, 10, 100, name="random")
             s_block_end()
 
         req2 = s_get("UNIT TEST 2")

--- a/unit_tests/test_string.py
+++ b/unit_tests/test_string.py
@@ -1,8 +1,17 @@
+from __future__ import division
+
+import math
 import unittest
+from collections import Counter, OrderedDict
 
 import pytest
+import six
+from future.standard_library import install_aliases
+from six.moves import map, zip
 
 from boofuzz import *
+
+install_aliases()
 
 
 @pytest.fixture(autouse=True)
@@ -18,15 +27,21 @@ class TestString(unittest.TestCase):
         self.default_default_value = "\x00" * len(self.default_value)
         return String(name="boofuzz-unit-test-name", default_value=self.default_value)
 
-    def _given_bytes_max_len(self, max_len):
-        self.default_value = b"ABCDEFGH"
+    def _given_string_max_len(self, max_len):
+        self.default_value = "ABCDEFGH"
         self.default_default_value = "\x00" * len(self.default_value)
-        return Bytes(name="boofuzz-unit-test-name", default_value=self.default_value, max_len=max_len)
+        return String(name="boofuzz-unit-test-name", default_value=self.default_value, max_len=max_len)
 
-    def _given_bytes_size(self, size, padding):
-        self.default_value = b"ABCDEFGH"
+    def _given_string_size(self, size, padding, encoding):
+        self.default_value = "ABCDEFGH"
         self.default_default_value = "\x00" * len(self.default_value)
-        return Bytes(name="boofuzz-unit-test-name", default_value=self.default_value, size=size, padding=padding)
+        return String(
+            name="boofuzz-unit-test-name",
+            default_value=self.default_value,
+            size=size,
+            padding=padding,
+            encoding=encoding,
+        )
 
     def test_mutations(self):
         uut = self._given_string()
@@ -46,7 +61,13 @@ class TestString(unittest.TestCase):
             for size in String._long_string_lengths:
                 for delta in String._long_string_deltas:
                     n += 1
-                    self.assertEqual(sequence * (size + delta), next(generator))
+                    expected = sequence * math.ceil((size + delta) / len(sequence))
+                    self.assertEqual(expected[: size + delta], next(generator))
+
+            for size in String._extra_long_string_lengths:
+                n += 1
+                expected = sequence * math.ceil(size / len(sequence))
+                self.assertEqual(expected[:size], next(generator))
 
         for size in String._long_string_lengths:
             s = "D" * size
@@ -55,101 +76,133 @@ class TestString(unittest.TestCase):
                 n += 1
                 self.assertEqual(s, next(generator))
 
-        for sequence in String.long_string_seeds:
-            for size in String._extra_long_string_lengths:
-                n += 1
-                self.assertEqual(sequence * size, next(generator))
-
         self.assertRaises(StopIteration, lambda: next(generator))
         self.assertEqual(n, uut.num_mutations(default_value=self.default_value))
+        list_of_duplicates = [
+            item for item, count in Counter(uut.mutations(default_value=self.default_value)).items() if count > 1
+        ]
+        self.assertEqual(0, len(list_of_duplicates))
 
-    # def test_mutations_max_len(self):
-    #     max_len = 7
-    #     uut = self._given_bytes_max_len(max_len=max_len)
-    #     generator = uut.mutations(default_value=self.default_default_value)
-    #
-    #     def truncate(b):
-    #         return b[0:max_len]
-    #
-    #     n = 0
-    #     for expected, actual in zip(map(truncate, uut._fuzz_library), generator):
-    #         n += 1
-    #         self.assertEqual(expected, actual)
-    #     for expected, actual in zip(uut._mutators_of_default_value, generator):
-    #         n += 1
-    #         self.assertEqual(truncate(expected(self.default_value)), actual(self.default_value))
-    #     for expected, actual in zip(map(truncate, uut._magic_debug_values), generator):
-    #         n += 1
-    #         self.assertEqual(expected, actual)
-    #     for i in range(0, len(self.default_default_value)):
-    #         for expected_fuzz_string in uut._fuzz_strings_1byte:
-    #             n += 1
-    #             actual_callable = next(generator)
-    #             actual_value = actual_callable(self.default_value)
-    #             expected_value = self.default_value[0:i] + expected_fuzz_string + self.default_value[i + 1 :]
-    #             self.assertEqual(truncate(expected_value), actual_value)
-    #     for i in range(0, len(self.default_default_value) - 1):
-    #         for expected_fuzz_string in uut._fuzz_strings_2byte:
-    #             n += 1
-    #             actual_callable = next(generator)
-    #             actual_value = actual_callable(self.default_value)
-    #             expected_value = self.default_value[0:i] + expected_fuzz_string + self.default_value[i + 2 :]
-    #             self.assertEqual(truncate(expected_value), actual_value)
-    #     for i in range(0, len(self.default_default_value) - 3):
-    #         for expected_fuzz_string in uut._fuzz_strings_4byte:
-    #             n += 1
-    #             actual_callable = next(generator)
-    #             actual_value = actual_callable(self.default_value)
-    #             expected_value = self.default_value[0:i] + expected_fuzz_string + self.default_value[i + 4 :]
-    #             self.assertEqual(truncate(expected_value), actual_value)
-    #
-    #     self.assertEqual(n, uut.num_mutations(default_value=self.default_value))
-    #
-    # def test_mutations_size(self):
-    #     size = 5
-    #     pad = b"\x41"
-    #
-    #     def fit_to_size(b):
-    #         fullpad = b"\x41" * 5
-    #         pad_len = max(0, size - len(b))
-    #         return b[0:size] + fullpad[0:pad_len]
-    #
-    #     uut = self._given_bytes_size(size=size, padding=pad)
-    #     generator = uut.mutations(default_value=self.default_default_value)
-    #
-    #     n = 0
-    #     for expected, actual in zip(map(fit_to_size, uut._fuzz_library), generator):
-    #         n += 1
-    #         self.assertEqual(expected, actual)
-    #     for expected, actual in zip(uut._mutators_of_default_value, generator):
-    #         n += 1
-    #         self.assertEqual(fit_to_size(expected(self.default_value)), actual(self.default_value))
-    #     for expected, actual in zip(map(fit_to_size, uut._magic_debug_values), generator):
-    #         n += 1
-    #         self.assertEqual(expected, actual)
-    #     for i in range(0, len(self.default_default_value)):
-    #         for expected_fuzz_string in uut._fuzz_strings_1byte:
-    #             n += 1
-    #             actual_callable = next(generator)
-    #             actual_value = actual_callable(self.default_value)
-    #             expected_value = self.default_value[0:i] + expected_fuzz_string + self.default_value[i + 1 :]
-    #             self.assertEqual(fit_to_size(expected_value), actual_value)
-    #     for i in range(0, len(self.default_default_value) - 1):
-    #         for expected_fuzz_string in uut._fuzz_strings_2byte:
-    #             n += 1
-    #             actual_callable = next(generator)
-    #             actual_value = actual_callable(self.default_value)
-    #             expected_value = self.default_value[0:i] + expected_fuzz_string + self.default_value[i + 2 :]
-    #             self.assertEqual(fit_to_size(expected_value), actual_value)
-    #     for i in range(0, len(self.default_default_value) - 3):
-    #         for expected_fuzz_string in uut._fuzz_strings_4byte:
-    #             n += 1
-    #             actual_callable = next(generator)
-    #             actual_value = actual_callable(self.default_value)
-    #             expected_value = self.default_value[0:i] + expected_fuzz_string + self.default_value[i + 4 :]
-    #             self.assertEqual(fit_to_size(expected_value), actual_value)
-    #
-    #     self.assertEqual(n, uut.num_mutations(default_value=self.default_value))
+    def test_mutations_max_len(self):
+        lengths = [5, 10, 128, 1000, 100000]
+
+        for max_len in lengths:
+            uut = self._given_string_max_len(max_len=max_len)
+            generator = uut.mutations(default_value=self.default_default_value)
+
+            def truncate(b):
+                return b[0:max_len]
+
+            n = 0
+            for expected, actual in zip(OrderedDict.fromkeys(list(map(truncate, String._fuzz_library))), generator):
+                n += 1
+                self.assertEqual(expected, actual)
+
+            for expected, actual in zip(String._variable_mutation_multipliers, generator):
+                n += 1
+                self.assertEqual(truncate(self.default_default_value * expected), actual)
+                if max_len <= len(self.default_default_value * expected):
+                    break
+
+            for sequence in String.long_string_seeds:
+                for size in String._long_string_lengths:
+                    for delta in String._long_string_deltas:
+                        if size + delta <= max_len:
+                            n += 1
+                            expected = sequence * math.ceil((size + delta) / len(sequence))
+                            self.assertEqual(truncate(expected[: size + delta]), next(generator))
+
+                for size in String._extra_long_string_lengths:
+                    if size <= max_len:
+                        n += 1
+                        expected = sequence * math.ceil(size / len(sequence))
+                        self.assertEqual(truncate(expected[:size]), next(generator))
+
+                if max_len < min(String._long_string_lengths[0], String._extra_long_string_lengths[0]) or max_len > max(
+                    String._long_string_lengths[-1] + String._long_string_deltas[-1],
+                    String._extra_long_string_lengths[-1],
+                ):
+                    n += 1
+                    expected = sequence * math.ceil(max_len / len(sequence))
+                    actual = next(generator)
+                    self.assertEqual(truncate(expected[:max_len]), actual)
+
+            for size in String._long_string_lengths:
+                if size <= max_len + 1:
+                    s = "D" * size
+                    for loc in uut.random_indices[size]:
+                        s = s[:loc] + "\x00" + s[loc:]
+                        n += 1
+                        self.assertEqual(truncate(s), next(generator))
+
+            self.assertRaises(StopIteration, lambda: next(generator))
+            self.assertEqual(n, uut.num_mutations(default_value=self.default_value))
+            list_of_duplicates = [
+                item for item, count in Counter(uut.mutations(default_value=self.default_value)).items() if count > 1
+            ]
+            self.assertEqual(0, len(list_of_duplicates))
+
+    def test_mutations_size(self):
+        lengths = [5, 10, 128, 1000, 100000]
+        pad = b"\x41"
+        encoding = "utf-8"
+
+        def fit_to_size(b):
+            b = six.ensure_binary(b[:max_len], encoding=encoding)
+            pad_len = max(0, max_len - len(b))
+            return b + pad * pad_len
+
+        for max_len in lengths:
+            uut = self._given_string_size(size=max_len, padding=pad, encoding=encoding)
+            generator = uut.mutations(default_value=self.default_default_value)
+
+            n = 0
+            for expected, actual in zip(OrderedDict.fromkeys(list(map(fit_to_size, String._fuzz_library))), generator):
+                n += 1
+                self.assertEqual(expected, uut.encode(actual))
+
+            for expected, actual in zip(String._variable_mutation_multipliers, generator):
+                n += 1
+                self.assertEqual(fit_to_size(self.default_default_value * expected), uut.encode(actual))
+                if max_len <= len(self.default_default_value * expected):
+                    break
+
+            for sequence in String.long_string_seeds:
+                for size in String._long_string_lengths:
+                    for delta in String._long_string_deltas:
+                        if size + delta <= max_len:
+                            n += 1
+                            expected = sequence * math.ceil((size + delta) / len(sequence))
+                            self.assertEqual(fit_to_size(expected[: size + delta]), uut.encode(next(generator)))
+
+                for size in String._extra_long_string_lengths:
+                    if size <= max_len:
+                        n += 1
+                        expected = sequence * math.ceil(size / len(sequence))
+                        self.assertEqual(fit_to_size(expected[:size]), uut.encode(next(generator)))
+
+                if max_len < min(String._long_string_lengths[0], String._extra_long_string_lengths[0]) or max_len > max(
+                    String._long_string_lengths[-1] + String._long_string_deltas[-1],
+                    String._extra_long_string_lengths[-1],
+                ):
+                    n += 1
+                    expected = sequence * math.ceil(max_len / len(sequence))
+                    self.assertEqual(fit_to_size(expected[:max_len]), uut.encode(next(generator)))
+
+            for length in String._long_string_lengths:
+                if length <= max_len + 1:
+                    s = "D" * length
+                    for loc in uut.random_indices[length]:
+                        s = s[:loc] + "\x00" + s[loc:]
+                        n += 1
+                        self.assertEqual(fit_to_size(s), uut.encode(next(generator)))
+
+            self.assertRaises(StopIteration, lambda: next(generator))
+            self.assertEqual(n, uut.num_mutations(default_value=self.default_value))
+            list_of_duplicates = [
+                item for item, count in Counter(uut.mutations(default_value=self.default_value)).items() if count > 1
+            ]
+            self.assertEqual(0, len(list_of_duplicates))
 
 
 if __name__ == "__main__":

--- a/unit_tests/test_string.py
+++ b/unit_tests/test_string.py
@@ -75,9 +75,9 @@ class TestString(unittest.TestCase):
         for size in String._long_string_lengths:
             s = "D" * size
             for loc in uut.random_indices[size]:
-                s = s[:loc] + "\x00" + s[loc:]
-                n += 1
-                self.assertEqual(s, next(generator))
+                s = s[:loc] + "\x00" + s[loc + 1 :]
+            n += 1
+            self.assertEqual(s, next(generator))
 
         self.assertRaises(StopIteration, lambda: next(generator))
         self.assertEqual(n, uut.num_mutations(default_value=self.default_value))
@@ -132,12 +132,12 @@ class TestString(unittest.TestCase):
                     self.assertEqual(truncate(expected), next(generator))
 
             for size in String._long_string_lengths:
-                if size <= max_len + 1:
+                if size <= max_len:
                     s = "D" * size
                     for loc in uut.random_indices[size]:
-                        s = s[:loc] + "\x00" + s[loc:]
-                        n += 1
-                        self.assertEqual(truncate(s), next(generator))
+                        s = s[:loc] + "\x00" + s[loc + 1 :]
+                    n += 1
+                    self.assertEqual(truncate(s), next(generator))
 
             self.assertRaises(StopIteration, lambda: next(generator))
             self.assertEqual(n, uut.num_mutations(default_value=self.default_value))
@@ -196,12 +196,12 @@ class TestString(unittest.TestCase):
                     self.assertEqual(fit_to_size(expected), uut.encode(next(generator)))
 
             for length in String._long_string_lengths:
-                if length <= max_len + 1:
+                if length <= max_len:
                     s = "D" * length
                     for loc in uut.random_indices[length]:
-                        s = s[:loc] + "\x00" + s[loc:]
-                        n += 1
-                        self.assertEqual(fit_to_size(s), uut.encode(next(generator)))
+                        s = s[:loc] + "\x00" + s[loc + 1 :]
+                    n += 1
+                    self.assertEqual(fit_to_size(s), uut.encode(next(generator)))
 
             self.assertRaises(StopIteration, lambda: next(generator))
             self.assertEqual(n, uut.num_mutations(default_value=self.default_value))

--- a/unit_tests/test_string.py
+++ b/unit_tests/test_string.py
@@ -75,9 +75,9 @@ class TestString(unittest.TestCase):
         for size in String._long_string_lengths:
             s = "D" * size
             for loc in uut.random_indices[size]:
-                s = s[:loc] + "\x00" + s[loc + 1 :]
-            n += 1
-            self.assertEqual(s, next(generator))
+                n += 1
+                expected = s[:loc] + "\x00" + s[loc + 1 :]
+                self.assertEqual(expected, next(generator))
 
         self.assertRaises(StopIteration, lambda: next(generator))
         self.assertEqual(n, uut.num_mutations(default_value=self.default_value))
@@ -135,9 +135,9 @@ class TestString(unittest.TestCase):
                 if size <= max_len:
                     s = "D" * size
                     for loc in uut.random_indices[size]:
-                        s = s[:loc] + "\x00" + s[loc + 1 :]
-                    n += 1
-                    self.assertEqual(truncate(s), next(generator))
+                        expected = s[:loc] + "\x00" + s[loc + 1 :]
+                        n += 1
+                        self.assertEqual(truncate(expected), next(generator))
 
             self.assertRaises(StopIteration, lambda: next(generator))
             self.assertEqual(n, uut.num_mutations(default_value=self.default_value))
@@ -199,9 +199,9 @@ class TestString(unittest.TestCase):
                 if length <= max_len:
                     s = "D" * length
                     for loc in uut.random_indices[length]:
-                        s = s[:loc] + "\x00" + s[loc + 1 :]
-                    n += 1
-                    self.assertEqual(fit_to_size(s), uut.encode(next(generator)))
+                        expected = s[:loc] + "\x00" + s[loc + 1 :]
+                        n += 1
+                        self.assertEqual(fit_to_size(expected), uut.encode(next(generator)))
 
             self.assertRaises(StopIteration, lambda: next(generator))
             self.assertEqual(n, uut.num_mutations(default_value=self.default_value))

--- a/unit_tests/test_string.py
+++ b/unit_tests/test_string.py
@@ -1,5 +1,6 @@
 from __future__ import division
 
+import itertools
 import math
 import unittest
 from collections import Counter, OrderedDict
@@ -58,11 +59,13 @@ class TestString(unittest.TestCase):
             self.assertEqual(self.default_default_value * expected, actual)
 
         for sequence in String.long_string_seeds:
-            for size in String._long_string_lengths:
-                for delta in String._long_string_deltas:
-                    n += 1
-                    expected = sequence * math.ceil((size + delta) / len(sequence))
-                    self.assertEqual(expected[: size + delta], next(generator))
+            for size in [
+                length + delta
+                for length, delta in itertools.product(String._long_string_lengths, String._long_string_deltas)
+            ]:
+                n += 1
+                expected = sequence * math.ceil(size / len(sequence))
+                self.assertEqual(expected[:size], next(generator))
 
             for size in String._extra_long_string_lengths:
                 n += 1
@@ -91,7 +94,7 @@ class TestString(unittest.TestCase):
             generator = uut.mutations(default_value=self.default_default_value)
 
             def truncate(b):
-                return b[0:max_len]
+                return b[:max_len]
 
             n = 0
             for expected, actual in zip(OrderedDict.fromkeys(list(map(truncate, String._fuzz_library))), generator):
@@ -105,12 +108,14 @@ class TestString(unittest.TestCase):
                     break
 
             for sequence in String.long_string_seeds:
-                for size in String._long_string_lengths:
-                    for delta in String._long_string_deltas:
-                        if size + delta <= max_len:
-                            n += 1
-                            expected = sequence * math.ceil((size + delta) / len(sequence))
-                            self.assertEqual(truncate(expected[: size + delta]), next(generator))
+                for size in [
+                    length + delta
+                    for length, delta in itertools.product(String._long_string_lengths, String._long_string_deltas)
+                ]:
+                    if size <= max_len:
+                        n += 1
+                        expected = sequence * math.ceil(size / len(sequence))
+                        self.assertEqual(truncate(expected[:size]), next(generator))
 
                 for size in String._extra_long_string_lengths:
                     if size <= max_len:
@@ -118,14 +123,13 @@ class TestString(unittest.TestCase):
                         expected = sequence * math.ceil(size / len(sequence))
                         self.assertEqual(truncate(expected[:size]), next(generator))
 
-                if max_len < min(String._long_string_lengths[0], String._extra_long_string_lengths[0]) or max_len > max(
-                    String._long_string_lengths[-1] + String._long_string_deltas[-1],
-                    String._extra_long_string_lengths[-1],
-                ):
+                if max_len not in String._extra_long_string_lengths + [
+                    length + delta
+                    for length, delta in itertools.product(String._long_string_lengths, String._long_string_deltas)
+                ]:
                     n += 1
                     expected = sequence * math.ceil(max_len / len(sequence))
-                    actual = next(generator)
-                    self.assertEqual(truncate(expected[:max_len]), actual)
+                    self.assertEqual(truncate(expected), next(generator))
 
             for size in String._long_string_lengths:
                 if size <= max_len + 1:
@@ -168,12 +172,14 @@ class TestString(unittest.TestCase):
                     break
 
             for sequence in String.long_string_seeds:
-                for size in String._long_string_lengths:
-                    for delta in String._long_string_deltas:
-                        if size + delta <= max_len:
-                            n += 1
-                            expected = sequence * math.ceil((size + delta) / len(sequence))
-                            self.assertEqual(fit_to_size(expected[: size + delta]), uut.encode(next(generator)))
+                for size in [
+                    length + delta
+                    for length, delta in itertools.product(String._long_string_lengths, String._long_string_deltas)
+                ]:
+                    if size <= max_len:
+                        n += 1
+                        expected = sequence * math.ceil(size / len(sequence))
+                        self.assertEqual(fit_to_size(expected[:size]), uut.encode(next(generator)))
 
                 for size in String._extra_long_string_lengths:
                     if size <= max_len:
@@ -181,13 +187,13 @@ class TestString(unittest.TestCase):
                         expected = sequence * math.ceil(size / len(sequence))
                         self.assertEqual(fit_to_size(expected[:size]), uut.encode(next(generator)))
 
-                if max_len < min(String._long_string_lengths[0], String._extra_long_string_lengths[0]) or max_len > max(
-                    String._long_string_lengths[-1] + String._long_string_deltas[-1],
-                    String._extra_long_string_lengths[-1],
-                ):
+                if max_len not in String._extra_long_string_lengths + [
+                    length + delta
+                    for length, delta in itertools.product(String._long_string_lengths, String._long_string_deltas)
+                ]:
                     n += 1
                     expected = sequence * math.ceil(max_len / len(sequence))
-                    self.assertEqual(fit_to_size(expected[:max_len]), uut.encode(next(generator)))
+                    self.assertEqual(fit_to_size(expected), uut.encode(next(generator)))
 
             for length in String._long_string_lengths:
                 if length <= max_len + 1:


### PR DESCRIPTION
Resolves #490

The string primitive will now truncate the test case data in a somewhat intelligent way, so it does no longer yield any duplicates.

As we don't have a list with all values which we can remove duplicates from, only the last value is compared with the current one and is dropped if equal. This requires the fuzz_library to be sorted.

I had to make some changes to the way num_mutation works. It no longer statically calculates all possible mutations as that would have been impossible/way to complex.
Now it generates the "static number of mutations" once and saves it while the "dynamic number of mutations", which depend on the length of the default value, is generated for each call.
However if anyone can thing of a better way to statically generate the correct number of mutations I'm happy to hear.

While writing the tests for the changes, I noticed that `helpers.str_to_bytes()` is incredibly slow. ~23000 took around 20 seconds to convert. Using six as a wrapper for str.encode() I was able to reduce that time down to something like 30ms. It might not have such a big impact when fuzzing a slow target but it's something right?
I chose utf-8 encoding as ascii felt too limiting for the testcases we have. Most characters would render as the default replacement `?`. However, the str_to_bytes function now takes an `encoding` argument which can be used to override the default.

BTW have I ever mentioned that I hate Python2? Just spend over 2 hours to backport this change...