### PR TITLE
Fix Python 3.9 compability

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -28,6 +28,7 @@ Fixes
 - Network monitor: fixed data_bytes calculation and PcapThread synchronization
 - Fixed a crash when using the network monitor
 - Session can now be "quiet" by passing an empty list of loggers
+- Process Monitor: fixed Thread.isAlive for Python 3.9 compability
 
 v0.2.1
 ------

--- a/boofuzz/utils/debugger_thread_pydbg.py
+++ b/boofuzz/utils/debugger_thread_pydbg.py
@@ -192,7 +192,7 @@ class DebuggerThreadPydbg(threading.Thread):
         # it is important to wait for the debugger thread to finish because it could be taking its sweet ass time
         # uncovering the details of the access violation.
         if av:
-            while self.isAlive():
+            while self.is_alive():
                 time.sleep(1)
 
         # serialize the crash bin to disk.

--- a/boofuzz/utils/process_monitor_local.py
+++ b/boofuzz/utils/process_monitor_local.py
@@ -79,7 +79,7 @@ class ProcessMonitorLocal(BaseMonitor):
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
-        if self.debugger_thread is not None and self.debugger_thread.isAlive():
+        if self.debugger_thread is not None and self.debugger_thread.is_alive():
             self.debugger_thread.stop_target()
 
     # noinspection PyMethodMayBeStatic
@@ -142,7 +142,7 @@ class ProcessMonitorLocal(BaseMonitor):
         self.log("pre_send(%d)" % test_number, 10)
         self.test_number = test_number
 
-        if self.debugger_thread is None or not self.debugger_thread.isAlive():
+        if self.debugger_thread is None or not self.debugger_thread.is_alive():
             self.start_target()
             self.debugger_thread.pre_send()
 
@@ -198,20 +198,20 @@ class ProcessMonitorLocal(BaseMonitor):
         time.sleep(1)
         if len(self.stop_commands) < 1:
             self.debugger_thread.stop_target()
-            while self.debugger_thread.isAlive():
+            while self.debugger_thread.is_alive():
                 time.sleep(0.1)
         else:
             for command in self.stop_commands:
                 if command == ["TERMINATE_PID"] or command == "TERMINATE_PID":
                     self.debugger_thread.stop_target()
-                    while self.debugger_thread.isAlive():
+                    while self.debugger_thread.is_alive():
                         time.sleep(0.1)
                 else:
                     self.log("Executing stop command: '{0}'".format(command), 2)
                     subprocess.Popen(command)
 
     def _target_is_running(self):
-        return self.debugger_thread is not None and self.debugger_thread.isAlive()
+        return self.debugger_thread is not None and self.debugger_thread.is_alive()
 
     def restart_target(self, **kwargs):
         """

--- a/boofuzz/utils/process_monitor_pedrpc_server.py
+++ b/boofuzz/utils/process_monitor_pedrpc_server.py
@@ -87,7 +87,7 @@ class ProcessMonitorPedrpcServer(pedrpc.Server):
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
-        if self.debugger_thread is not None and self.debugger_thread.isAlive():
+        if self.debugger_thread is not None and self.debugger_thread.is_alive():
             self.debugger_thread.stop_target()
         self.stop()
 
@@ -144,7 +144,7 @@ class ProcessMonitorPedrpcServer(pedrpc.Server):
         self.log("pre_send(%d)" % test_number, 10)
         self.test_number = test_number
 
-        if self.debugger_thread is None or not self.debugger_thread.isAlive():
+        if self.debugger_thread is None or not self.debugger_thread.is_alive():
             self.start_target()
             self.debugger_thread.pre_send()
 
@@ -200,20 +200,20 @@ class ProcessMonitorPedrpcServer(pedrpc.Server):
         time.sleep(1)
         if len(self.stop_commands) < 1:
             self.debugger_thread.stop_target()
-            while self.debugger_thread.isAlive():
+            while self.debugger_thread.is_alive():
                 time.sleep(0.1)
         else:
             for command in self.stop_commands:
                 if command == ["TERMINATE_PID"] or command == "TERMINATE_PID":
                     self.debugger_thread.stop_target()
-                    while self.debugger_thread.isAlive():
+                    while self.debugger_thread.is_alive():
                         time.sleep(0.1)
                 else:
                     self.log("Executing stop command: '{0}'".format(command), 2)
                     subprocess.Popen(command)
 
     def _target_is_running(self):
-        return self.debugger_thread is not None and self.debugger_thread.isAlive()
+        return self.debugger_thread is not None and self.debugger_thread.is_alive()
 
     def restart_target(self):
         """


### PR DESCRIPTION
This replaces threading.Thread.isAlive with is_alive (available since Python 2.6) in the process monitor rpc calls because isAlive has been dropped in Python 3.9.