### PR TITLE
Fuzz CLI Helper

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+Upcoming
+--------
+Features
+^^^^^^^^
+- Fuzzing CLI -- Use main_helper() to use boofuzz's generic fuzzing CLI with your script.
+
 v0.3.0
 ------
 Features

--- a/boofuzz/__init__.py
+++ b/boofuzz/__init__.py
@@ -8,6 +8,7 @@ from past.builtins import map
 
 from . import blocks, exception, legos, primitives
 from .blocks import Aligned, Block, Checksum, Repeat, Request, REQUESTS, Size
+from .cli import main_helper
 from .connections import (
     BaseSocketConnection,
     FileConnection,
@@ -102,6 +103,7 @@ __all__ = [
     "ITargetConnection",
     "legos",
     "LITTLE_ENDIAN",
+    "main_helper",
     "Mirror",
     "MustImplementException",
     "NetworkMonitor",

--- a/boofuzz/cli.py
+++ b/boofuzz/cli.py
@@ -25,31 +25,47 @@ def cli():
 
 
 @cli.group()
-@click.option('--target-host', help='Host or IP address of target', required=True)
-@click.option('--target-port', type=int, help='Network port of target', required=True)
-@click.option('--test-case-index', help='Test case index', type=int)
-@click.option('--test-case-name', help='Name of node or specific test case')
-@click.option('--csv-out', help='Output to CSV file')
-@click.option('--sleep-between-cases', help='Wait time between test cases (floating point)', type=float, default=0)
-@click.option('--procmon-host', help='Process monitor port host or IP')
-@click.option('--procmon-port', type=int, default=DEFAULT_PROCMON_PORT, help='Process monitor port')
-@click.option('--procmon-start', help='Process monitor start command')
-@click.option('--procmon-capture', is_flag=True, help='Capture stdout/stderr from target process upon failure')
-@click.option('--tui/--no-tui', help='Enable/disable TUI')
-@click.option('--text-dump/--no-text-dump', help='Enable/disable full text dump of logs', default=False)
-@click.option('--feature-check', is_flag=True, help='Run a feature check instead of a fuzz test', default=False)
-@click.option('--target-cmd', help='Target command and arguments')
+@click.option("--target-host", help="Host or IP address of target", required=True)
+@click.option("--target-port", type=int, help="Network port of target", required=True)
+@click.option("--test-case-index", help="Test case index", type=int)
+@click.option("--test-case-name", help="Name of node or specific test case")
+@click.option("--csv-out", help="Output to CSV file")
+@click.option("--sleep-between-cases", help="Wait time between test cases (floating point)", type=float, default=0)
+@click.option("--procmon-host", help="Process monitor port host or IP")
+@click.option("--procmon-port", type=int, default=DEFAULT_PROCMON_PORT, help="Process monitor port")
+@click.option("--procmon-start", help="Process monitor start command")
+@click.option("--procmon-capture", is_flag=True, help="Capture stdout/stderr from target process upon failure")
+@click.option("--tui/--no-tui", help="Enable/disable TUI")
+@click.option("--text-dump/--no-text-dump", help="Enable/disable full text dump of logs", default=False)
+@click.option("--feature-check", is_flag=True, help="Run a feature check instead of a fuzz test", default=False)
+@click.option("--target-cmd", help="Target command and arguments")
 @click.pass_context
-def fuzz(ctx, target_host, target_port,
-         test_case_index, test_case_name, csv_out, sleep_between_cases,
-         procmon_host, procmon_port, procmon_start, procmon_capture, tui, text_dump, feature_check, target_cmd):
+def fuzz(
+    ctx,
+    target_host,
+    target_port,
+    test_case_index,
+    test_case_name,
+    csv_out,
+    sleep_between_cases,
+    procmon_host,
+    procmon_port,
+    procmon_start,
+    procmon_capture,
+    tui,
+    text_dump,
+    feature_check,
+    target_cmd,
+):
     local_procmon = None
     if target_cmd is not None and procmon_host is None:
-        local_procmon = ProcessMonitorLocal(crash_filename="boofuzz-crash-bin",
-                                            proc_name=None,  # "proftpd",
-                                            pid_to_ignore=None,
-                                            debugger_class=DebuggerThreadSimple,
-                                            level=1)
+        local_procmon = ProcessMonitorLocal(
+            crash_filename="boofuzz-crash-bin",
+            proc_name=None,  # "proftpd",
+            pid_to_ignore=None,
+            debugger_class=DebuggerThreadSimple,
+            level=1,
+        )
 
     fuzz_loggers = []
     if text_dump:
@@ -57,16 +73,16 @@ def fuzz(ctx, target_host, target_port,
     elif tui:
         fuzz_loggers.append(FuzzLoggerCurses())
     if csv_out is not None:
-        f = open('ftp-fuzz.csv', 'wb')  # TODO more generic filename, specifically in the boofuzz-results folder
+        f = open("ftp-fuzz.csv", "wb")  # TODO more generic filename, specifically in the boofuzz-results folder
         fuzz_loggers.append(FuzzLoggerCsv(file_handle=f))
 
     procmon_options = {}
     if procmon_start is not None:
-        procmon_options['start_commands'] = [procmon_start]
+        procmon_options["start_commands"] = [procmon_start]
     if target_cmd is not None:
-        procmon_options['start_commands'] = shlex.split(target_cmd)
+        procmon_options["start_commands"] = shlex.split(target_cmd)
     if procmon_capture:
-        procmon_options['capture_output'] = True
+        procmon_options["capture_output"] = True
 
     if local_procmon is not None or procmon_host is not None:
         if procmon_host is not None:
@@ -170,7 +186,6 @@ def main_helper(click_command=None):
     if click_command is not None:
         fuzz.add_command(click_command)
     main()
-
 
 
 if __name__ == "__main__":

--- a/boofuzz/cli.py
+++ b/boofuzz/cli.py
@@ -34,7 +34,9 @@ def cli():
 @click.option("--test-case-index", help="Test case index", type=int)
 @click.option("--test-case-name", help="Name of node or specific test case")
 @click.option("--csv-out", help="Output to CSV file")
-@click.option("--sleep-between-cases", help="Wait FLOAT (seconds) between test cases (partial seconds OK)", type=float, default=0)
+@click.option(
+    "--sleep-between-cases", help="Wait FLOAT (seconds) between test cases (partial seconds OK)", type=float, default=0
+)
 @click.option("--procmon-host", help="Process monitor port host or IP")
 @click.option("--procmon-port", type=int, default=DEFAULT_PROCMON_PORT, help="Process monitor port")
 @click.option("--procmon-start", help="Process monitor start command")

--- a/boofuzz/cli.py
+++ b/boofuzz/cli.py
@@ -77,7 +77,7 @@ def fuzz(
     elif tui:
         fuzz_loggers.append(FuzzLoggerCurses())
     if csv_out is not None:
-        f = open("boofuzz.csv", 'wb')
+        f = open("boofuzz.csv", "wb")
         fuzz_loggers.append(FuzzLoggerCsv(file_handle=f))
 
     procmon_options = {}

--- a/boofuzz/cli.py
+++ b/boofuzz/cli.py
@@ -2,16 +2,133 @@
 from __future__ import print_function
 
 import logging
+import shlex
 import time
 
 import click
 
 from . import constants, sessions
+from .cli_context import CliContext
+from .constants import DEFAULT_PROCMON_PORT
+from .connections import TCPSocketConnection
+from .utils.process_monitor_local import ProcessMonitorLocal
+from .utils.debugger_thread_simple import DebuggerThreadSimple
+
+temp_static_session = None
+temp_static_procmon = None
+temp_static_fuzz_only_one_case = None
 
 
 @click.group()
 def cli():
     pass
+
+
+@cli.group()
+@click.option('--target-host', help='Host or IP address of target', required=True)
+@click.option('--target-port', type=int, help='Network port of target', required=True)
+@click.option('--test-case-index', help='Test case index', type=int)
+@click.option('--test-case-name', help='Name of node or specific test case')
+@click.option('--csv-out', help='Output to CSV file')
+@click.option('--sleep-between-cases', help='Wait time between test cases (floating point)', type=float, default=0)
+@click.option('--procmon-host', help='Process monitor port host or IP')
+@click.option('--procmon-port', type=int, default=DEFAULT_PROCMON_PORT, help='Process monitor port')
+@click.option('--procmon-start', help='Process monitor start command')
+@click.option('--procmon-capture', is_flag=True, help='Capture stdout/stderr from target process upon failure')
+@click.option('--tui/--no-tui', help='Enable/disable TUI')
+@click.option('--text-dump/--no-text-dump', help='Enable/disable full text dump of logs', default=False)
+@click.option('--feature-check', is_flag=True, help='Run a feature check instead of a fuzz test', default=False)
+@click.option('--target-cmd', help='Target command and arguments')
+@click.pass_context
+def fuzz(ctx, target_host, target_port,
+         test_case_index, test_case_name, csv_out, sleep_between_cases,
+         procmon_host, procmon_port, procmon_start, procmon_capture, tui, text_dump, feature_check, target_cmd):
+    local_procmon = None
+    if target_cmd is not None and procmon_host is None:
+        local_procmon = ProcessMonitorLocal(crash_filename="boofuzz-crash-bin",
+                                            proc_name=None,  # "proftpd",
+                                            pid_to_ignore=None,
+                                            debugger_class=DebuggerThreadSimple,
+                                            level=1)
+
+    fuzz_loggers = []
+    if text_dump:
+        fuzz_loggers.append(FuzzLoggerText())
+    elif tui:
+        fuzz_loggers.append(FuzzLoggerCurses())
+    if csv_out is not None:
+        f = open('ftp-fuzz.csv', 'wb')  # TODO more generic filename, specifically in the boofuzz-results folder
+        fuzz_loggers.append(FuzzLoggerCsv(file_handle=f))
+
+    procmon_options = {}
+    if procmon_start is not None:
+        procmon_options['start_commands'] = [procmon_start]
+    if target_cmd is not None:
+        procmon_options['start_commands'] = shlex.split(target_cmd)
+    if procmon_capture:
+        procmon_options['capture_output'] = True
+
+    if local_procmon is not None or procmon_host is not None:
+        if procmon_host is not None:
+            procmon = ProcessMonitor(procmon_host, procmon_port)
+        else:
+            procmon = local_procmon
+        procmon.set_options(**procmon_options)
+        monitors = [procmon]
+    else:
+        procmon = None
+        monitors = []
+
+    start = None
+    end = None
+    fuzz_only_one_case = None
+    if test_case_index is None:
+        start = 1
+    elif "-" in test_case_index:
+        start, end = test_case_index.split("-")
+        if not start:
+            start = 1
+        else:
+            start = int(start)
+        if not end:
+            end = None
+        else:
+            end = int(end)
+    else:
+        fuzz_only_one_case = int(test_case_index)
+
+    connection = TCPSocketConnection(target_host, target_port)
+
+    session = sessions.Session(
+        target=sessions.Target(
+            connection=connection,
+            monitors=monitors,
+        ),
+        fuzz_loggers=fuzz_loggers,
+        sleep_time=sleep_between_cases,
+        index_start=start,
+        index_end=end,
+    )
+
+    ctx.obj = CliContext(session=session)
+
+    # TODO if no subcommand script provided then error out and warn
+    # Future: Either rely on a Click subcommand, or manually call a function provided by the user
+
+    # The resultcallback is called after any subcommands, e.g. the one provided by the user
+    @fuzz.resultcallback()
+    def fuzzcallback(result, *args, **kwargs):
+        if feature_check:
+            session.feature_check()
+        elif fuzz_only_one_case is not None:
+            session.fuzz_single_case(mutant_index=fuzz_only_one_case)
+        elif test_case_name is not None:
+            session.fuzz_by_name(test_case_name)
+        else:
+            session.fuzz()
+
+        if procmon is not None:
+            procmon.stop_target()
 
 
 @cli.command(name="open")
@@ -43,6 +160,17 @@ def open_file(debug, filename, ui_port, ui_addr):
 
 def main():
     cli()
+
+
+def main_helper(click_command=None):
+    """
+    Args:
+        click_command (click.Command): Click command to add as a sub-command to boo fuzz.
+    """
+    if click_command is not None:
+        fuzz.add_command(click_command)
+    main()
+
 
 
 if __name__ == "__main__":

--- a/boofuzz/cli.py
+++ b/boofuzz/cli.py
@@ -14,6 +14,7 @@ from .connections import TCPSocketConnection
 from .fuzz_logger_csv import FuzzLoggerCsv
 from .fuzz_logger_curses import FuzzLoggerCurses
 from .fuzz_logger_text import FuzzLoggerText
+from .helpers import parse_target
 from .monitors import ProcessMonitor
 from .utils.process_monitor_local import ProcessMonitorLocal
 from .utils.debugger_thread_simple import DebuggerThreadSimple
@@ -29,12 +30,11 @@ def cli():
 
 
 @cli.group(help="Must be run via a fuzz script")
-@click.option("--target-host", help="Host or IP address of target", required=True)
-@click.option("--target-port", type=int, help="Network port of target", required=True)
+@click.option("--target", metavar="HOST:PORT", help="Target network address", required=True)
 @click.option("--test-case-index", help="Test case index", type=int)
 @click.option("--test-case-name", help="Name of node or specific test case")
 @click.option("--csv-out", help="Output to CSV file")
-@click.option("--sleep-between-cases", help="Wait time between test cases (floating point)", type=float, default=0)
+@click.option("--sleep-between-cases", help="Wait FLOAT (seconds) between test cases (partial seconds OK)", type=float, default=0)
 @click.option("--procmon-host", help="Process monitor port host or IP")
 @click.option("--procmon-port", type=int, default=DEFAULT_PROCMON_PORT, help="Process monitor port")
 @click.option("--procmon-start", help="Process monitor start command")
@@ -46,8 +46,7 @@ def cli():
 @click.pass_context
 def fuzz(
     ctx,
-    target_host,
-    target_port,
+    target,
     test_case_index,
     test_case_name,
     csv_out,
@@ -117,7 +116,7 @@ def fuzz(
     else:
         fuzz_only_one_case = int(test_case_index)
 
-    connection = TCPSocketConnection(target_host, target_port)
+    connection = TCPSocketConnection(*parse_target(target_name=target))
 
     session = sessions.Session(
         target=sessions.Target(

--- a/boofuzz/cli_context.py
+++ b/boofuzz/cli_context.py
@@ -1,0 +1,9 @@
+import attr
+
+from .sessions import Session
+
+
+@attr.s
+class CliContext(object):
+    """Context for Click commands' Context.obj """
+    session = attr.ib(type=Session)

--- a/boofuzz/cli_context.py
+++ b/boofuzz/cli_context.py
@@ -6,4 +6,5 @@ from .sessions import Session
 @attr.s
 class CliContext(object):
     """Context for Click commands' Context.obj """
+
     session = attr.ib(type=Session)

--- a/boofuzz/helpers.py
+++ b/boofuzz/helpers.py
@@ -441,3 +441,11 @@ def get_boofuzz_version(boofuzz_class):
 
 def str_to_bytes(value, encoding="utf-8", errors="replace"):
     return six.ensure_binary(value, encoding=encoding, errors=errors)
+
+
+def parse_target(target_name):
+    try:
+        host, ip = target_name.split(":")
+        return host, int(ip)
+    except ValueError:
+        raise ValueError("Target format is HOST:PORT")


### PR DESCRIPTION
Experimental approach to standard fuzzing CLI. Allows your fuzz script to use/extend a pre-packaged CLI supporting many boofuzz features.

Goals:

1. Standard CLI for common fuzzing options.
2. Allow custom CLI for particular fuzzing scripts.
3. Decouple core fuzzer and fuzz scripts.

To use:

1. Define your fuzz method using `@click.command` (see [click](https://click.palletsprojects.com/)).
2. Call main `boofuzz.main_helper(click_command=fuzzmethod)` to add your fuzzer.
3. Call `yourscript.py fuzz fuzzmethod` to start fuzzing.
4. boofuzz-provided arguments should be passed to the fuzz subcommand. Your own custom arguments should be passed to your own fuzzmethod. Example:
   
   ```
   python ftp.py fuzz --target-host 127.0.0.1 --target-port 21 --target-cmd 'ftp-target.sh' ftp --username anonymous --password admin
   ```
