### PR TITLE
Correctly set l2_dst arg type to bytes

### DIFF
--- a/boofuzz/connections/raw_l3_socket_connection.py
+++ b/boofuzz/connections/raw_l3_socket_connection.py
@@ -23,7 +23,7 @@ class RawL3SocketConnection(base_socket_connection.BaseSocketConnection):
         send_timeout (float): Seconds to wait for send before timing out. Default 5.0.
         recv_timeout (float): Seconds to wait for recv before timing out. Default 5.0.
         ethernet_proto (int): Ethernet protocol to bind to. Defaults to ETH_P_IP (0x0800).
-        l2_dst (str): Layer2 destination address (e.g. MAC address). Default '\xFF\xFF\xFF\xFF\xFF\xFF' (broadcast)
+        l2_dst (bytes): Layer2 destination address (e.g. MAC address). Default b'\xFF\xFF\xFF\xFF\xFF\xFF' (broadcast)
         packet_size (int): Maximum packet size (in bytes). Default 1500 if the underlying interface uses
             standard ethernet for layer 2. Otherwise, a different packet size may apply (e.g. Jumboframes,
             802.5 Token Ring, 802.11 wifi, ...) that must be specified.


### PR DESCRIPTION
Passing the l2_dest e.g. MAC address as bytes seems to be more suitable here and prevents issues with encoding.

The default value is already a bytes type, this PR just adapts the documentation.

Please correct me if it should be a string typed value.