### PR TITLE
Make impacket dependency optional

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -178,10 +178,10 @@ and has been replaced with boofuzz’s logging mechanisms.
 However, some people still prefer the PCAP approach.
 
 .. note::
-    The network monitor requires Pcapy, which will not be automatically installed with boofuzz. You can manually
-    install it with ``pip install pcapy``.
+    The network monitor requires Pcapy and Impacket, which will not be automatically installed with boofuzz. You can
+    manually install them with ``pip install pcapy impacket``.
 
-    If you run into errors, check out the requirements on the `project page <https://github.com/helpsystems/pcapy>`_.
+    If you run into errors, check out the Pcapy requirements on the `project page <https://github.com/helpsystems/pcapy>`_.
 
 .. _help site: http://www.howtogeek.com/197947/how-to-install-python-on-windows/
 .. _releases page: https://github.com/jtpereyda/boofuzz/releases

--- a/network_monitor.py
+++ b/network_monitor.py
@@ -4,8 +4,7 @@ import sys
 import threading
 import time
 from io import open
-import impacket
-import impacket.ImpactDecoder
+import impacket.ImpactDecoder  # pytype: disable=import-error
 
 import netifaces as ni
 

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,6 @@ setup(
         "Flask",
         "funcy",
         "future",
-        "impacket",
         "psutil",
         "pyserial",
         "pydot",


### PR DESCRIPTION
The only place where impacket is needed is in the network_monitor. In the same file we also import pcapy, which is not listed as a dependency while impacket is.

To reduce the number of dependencies and so the number of possible problems and conflicts (#249), I suggest to remove it as a dependency. Whoever wants to use the network monitor will have to install impacket manually.

Another argument for removing the dependency is that the network monitor is more of an optional tool that comes with boofuzz rather than a part of the boofuzz packet itself.

I'm picking this up because I just had a case where people, let's say, were suspicious about the presence of impacket on their systems.