### PR TITLE
Run flake8 with Python 3

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -6,6 +6,7 @@ linters:
     config: ./pyproject.toml
     fixer: true
   flake8:
+    python: 3
     config: ./setup.cfg
     fixer: true
   pytype:


### PR DESCRIPTION
This should fix some Stickler CI annotations about Python 2 incompatible code.