### PR TITLE
Use a local random number generator instead of the global one

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ Features
 Fixes
 ^^^^^
 - Clarified Checksum() data for custom checksum function.
+- String and RandomData primitives now use a local and independent instance of random
 
 v0.3.0
 ------

--- a/boofuzz/primitives/random_data.py
+++ b/boofuzz/primitives/random_data.py
@@ -55,8 +55,7 @@ class RandomData(Fuzzable):
             str: Mutations
         """
 
-        # TODO use a non-zero seed (once each run has its own seed)
-        local_random = random.Random(0)
+        local_random = random.Random(0)  # We want constant random numbers to generate reproducible test cases
 
         for i in range(0, self.get_num_mutations()):
             # select a random length for this string.

--- a/boofuzz/primitives/random_data.py
+++ b/boofuzz/primitives/random_data.py
@@ -54,17 +54,21 @@ class RandomData(Fuzzable):
         Yields:
             str: Mutations
         """
+
+        # TODO use a non-zero seed (once each run has its own seed)
+        local_random = random.Random(0)
+
         for i in range(0, self.get_num_mutations()):
             # select a random length for this string.
             if not self.step:
-                length = random.randint(self.min_length, self.max_length)
+                length = local_random.randint(self.min_length, self.max_length)
             # select a length function of the mutant index and the step.
             else:
                 length = self.min_length + i * self.step
 
             value = b""
             for _ in xrange(length):
-                value += struct.pack("B", random.randint(0, 255))
+                value += struct.pack("B", local_random.randint(0, 255))
             yield value
 
     def encode(self, value, mutation_context):

--- a/boofuzz/primitives/string.py
+++ b/boofuzz/primitives/string.py
@@ -205,13 +205,13 @@ class String(Fuzzable):
         self._static_num_mutations = None
         self.random_indices = {}
 
-        random.seed(0)  # We want constant random numbers to generate reproducible test cases
+        local_random = random.Random(0)  # We want constant random numbers to generate reproducible test cases
         previous_length = 0
         # For every length add a random number of random indices to the random_indices dict. Prevent duplicates by
         # adding only indices in between previous_length and current length.
         for length in self._long_string_lengths:
-            self.random_indices[length] = random.sample(
-                range(previous_length, length), random.randint(1, self._long_string_lengths[0])
+            self.random_indices[length] = local_random.sample(
+                range(previous_length, length), local_random.randint(1, self._long_string_lengths[0])
             )
             previous_length = length
 


### PR DESCRIPTION
String currently affects the global random module (by calling random.seed(0) ), which may affect other logic in boofuzz or scripts that use it. I modified it to use a local random.Random() instance with seed 0 - it produces the same results without affecting the random module itself.