### PR TITLE
Activate dependabot for Github Actions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -10,5 +10,5 @@ recursive-include request_definitions *.html *.py
 recursive-include unit_tests *.feature *.py
 recursive-include utils *.py
 
-exclude .readthedocs.yml .travis.yml codecov.yml
+exclude .readthedocs.yml .travis.yml codecov.yml dependabot.yml
 prune docs/_build

--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
I noticed that we can use dependabot to update our github action workflows.

That saves us the work of updating them manually.

It will open a PR weekly if there are any updates.