### PR TITLE
Drop Python 3.5 support

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,11 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: [3.5, 3.6, 3.7, 3.8, 3.9]
-        # Exclude Python 3.5 on windows (compiler missing)
-        exclude:
-          - os: windows-latest
-            python-version: 3.5
+        python-version: [3.6, 3.7, 3.8, 3.9]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,7 @@ Fixes
 ^^^^^
 - Clarified Checksum() data for custom checksum function.
 - String and RandomData primitives now use a local and independent instance of random
+- The minimum supported Python version is now 3.6
 
 v0.3.0
 ------

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@
 import ast
 import os
 import re
-import sys
 from io import open
 
 from setuptools import find_packages, setup
@@ -34,6 +33,7 @@ def get_long_description():
 
 extra_requirements = {
     "dev": [
+        "black",
         "tox",
         "flake8",
         "check-manifest",
@@ -48,10 +48,6 @@ extra_requirements = {
     "docs": ["sphinx", "sphinx_rtd_theme", "pygments>=2.4.0"],
 }
 extra_requirements["dev"] += extra_requirements["docs"]
-
-if sys.version_info >= (3, 6):
-    extra_requirements["dev"] += ["black"]
-
 
 setup(
     name="boofuzz",
@@ -78,7 +74,7 @@ setup(
         "tornado",
     ],
     extras_require=extra_requirements,
-    python_requires=">=3.5",
+    python_requires=">=3.6",
     entry_points={"console_scripts": ["boo=boofuzz.cli:main"]},
     classifiers=[
         "Development Status :: 4 - Beta",
@@ -91,7 +87,6 @@ setup(
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion=2.0
 skip_missing_interpreters = True
-envlist = py{35,36,37,38,39}-{Linux,Windows,macOS}, docs, lint
+envlist = py{36,37,38,39}-{Linux,Windows,macOS}, docs, lint
 
 [testenv]
 platform =


### PR DESCRIPTION
In #511 we noticed that Python 3.5 is not compatible with some new features like trailing commas in argument lists or type hints.

As type hints are a great thing IMHO and less than 3% are using Python 3.5 according to this [survey](https://www.jetbrains.com/lp/python-developers-survey-2020/), I suggest to drop support for it.