### PR TITLE
 fix the return status check of subprocess

### DIFF
--- a/boofuzz/utils/debugger_thread_simple.py
+++ b/boofuzz/utils/debugger_thread_simple.py
@@ -155,8 +155,9 @@ class DebuggerThreadSimple(threading.Thread):
             exit_info = os.waitpid(self.pid, 0)
             self.exit_status = exit_info[1]  # [0] is the pid
 
-        default_reason = "Process died for unknown reason"
-        if self.exit_status is not None:
+        msg = ""
+        
+        if self.exit_status:
             if os.WCOREDUMP(self.exit_status):
                 reason = "Segmentation fault"
             elif os.WIFSTOPPED(self.exit_status):
@@ -166,9 +167,10 @@ class DebuggerThreadSimple(threading.Thread):
             elif os.WIFEXITED(self.exit_status):
                 reason = "Exit with code - " + str(os.WEXITSTATUS(self.exit_status))
             else:
-                reason = default_reason
-        else:
-            reason = default_reason
+                reason = "Process died for unknown reason"
+            msg += "[{0}] Crash. Exit code: {1}. Reason - {2}\n".format(
+                time.strftime("%I:%M.%S"), self.exit_status if self.exit_status else "<unknown>", reason
+            )
 
         outdata = None
         errdata = None
@@ -180,9 +182,6 @@ class DebuggerThreadSimple(threading.Thread):
                 msg="Expired waiting for process {0} to terminate".format(self._process.pid), level=1
             )
 
-        msg = "[{0}] Crash. Exit code: {1}. Reason - {2}\n".format(
-            time.strftime("%I:%M.%S"), self.exit_status if self.exit_status is not None else "<unknown>", reason
-        )
         if errdata is not None:
             msg += "STDERR:\n{0}\n".format(errdata.decode("ascii"))
         if outdata is not None:

--- a/boofuzz/utils/debugger_thread_simple.py
+++ b/boofuzz/utils/debugger_thread_simple.py
@@ -169,7 +169,7 @@ class DebuggerThreadSimple(threading.Thread):
             else:
                 reason = "Process died for unknown reason"
             msg += "[{0}] Crash. Exit code: {1}. Reason - {2}\n".format(
-                time.strftime("%I:%M.%S"), self.exit_status if self.exit_status else "<unknown>", reason
+                time.strftime("%I:%M.%S"), self.exit_status, reason
             )
 
         outdata = None


### PR DESCRIPTION
The description of `os.waitpid` is:
```
waitpid(...)
    waitpid(pid, options) -> (pid, status)

    Wait for completion of a given child process.
```
The return value of `os.waitpid` is a tuple thus the `self.exit_status` can not be `None`.
