### PR TITLE
BER Integer: super call needs to be applied to self

### DIFF
--- a/boofuzz/legos/ber.py
+++ b/boofuzz/legos/ber.py
@@ -59,7 +59,7 @@ class Integer(blocks.Block):
         if not options:
             options = {}
 
-        super(Integer).__init__(name, request)
+        super(Integer, self).__init__(name, request)
 
         self.value = value
         self.options = options


### PR DESCRIPTION
I'm not quite python fluent, but during my tests with BER / Integers legos, I had the following crash :

```
Traceback (most recent call last):
  File "[...]./test.py", line 70, in <module>
    s_lego("ber_integer", 1000)  # size limit
  File "[...]/boofuzz/env/lib64/python3.9/site-packages/boofuzz/__init__.py", line 650, in s_lego
    lego = legos.BIN[lego_type](name, blocks.CURRENT, value, options)
  File "[...]/boofuzz/env/lib64/python3.9/site-packages/boofuzz/legos/ber.py", line 62, in __init__
    super(Integer).__init__(name, request)
TypeError: super() argument 1 must be type, not str
```

I think there's a missing `self` argument (e.g.: looking a how the BER/Strings are constructed, a few lines above).

The patch seems to help