### PR TITLE
Add type checking for args of Bytes primitive

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,10 @@ Features
 ^^^^^^^^
 - Added support for fuzzing NETCONF servers with the `NETCONFConnection` class.
 
+Fixes
+^^^^^
+- Added type checking for arguments of `Bytes` primitive to prevent incorrect use.
+
 v0.4.0
 ------
 Features

--- a/boofuzz/primitives/bytes.py
+++ b/boofuzz/primitives/bytes.py
@@ -1,5 +1,6 @@
 import functools
 import operator
+import typing
 
 from funcy import compose
 
@@ -119,11 +120,24 @@ class Bytes(Fuzzable):
         functools.partial(operator.mul, 100),
     ]
 
-    def __init__(self, name=None, default_value=b"", size=None, padding=b"\x00", max_len=None, *args, **kwargs):
-        if not isinstance(default_value, bytes):
-            raise TypeError("default_value must be bytes type")
-        if not isinstance(padding, bytes):
-            raise TypeError("padding must be bytes type")
+    def __init__(
+        self,
+        name: str = None,
+        default_value: typing.Union[bytes, memoryview] = b"",
+        size: int = None,
+        padding: typing.Union[bytes, memoryview] = b"\x00",
+        max_len: int = None,
+        *args,
+        **kwargs
+    ):
+        try:
+            memoryview(default_value)
+        except TypeError:
+            raise TypeError("default_value of Bytes must be bytes-like type")
+        try:
+            memoryview(padding)
+        except TypeError:
+            raise TypeError("padding of Bytes must be bytes-like type")
 
         super(Bytes, self).__init__(name=name, default_value=default_value, *args, **kwargs)
 

--- a/boofuzz/primitives/bytes.py
+++ b/boofuzz/primitives/bytes.py
@@ -1,6 +1,6 @@
 import functools
 import operator
-import typing
+from collections.abc import ByteString
 
 from funcy import compose
 
@@ -123,21 +123,17 @@ class Bytes(Fuzzable):
     def __init__(
         self,
         name: str = None,
-        default_value: typing.Union[bytes, memoryview] = b"",
+        default_value: bytes = b"",
         size: int = None,
-        padding: typing.Union[bytes, memoryview] = b"\x00",
+        padding: bytes = b"\x00",
         max_len: int = None,
         *args,
         **kwargs
     ):
-        try:
-            memoryview(default_value)
-        except TypeError:
-            raise TypeError("default_value of Bytes must be bytes-like type")
-        try:
-            memoryview(padding)
-        except TypeError:
-            raise TypeError("padding of Bytes must be bytes-like type")
+        if not isinstance(default_value, ByteString):
+            raise TypeError("default_value of Bytes must be of ByteString type")
+        if not isinstance(padding, ByteString):
+            raise TypeError("padding of Bytes must be of ByteString type")
 
         super(Bytes, self).__init__(name=name, default_value=default_value, *args, **kwargs)
 

--- a/boofuzz/primitives/bytes.py
+++ b/boofuzz/primitives/bytes.py
@@ -120,6 +120,11 @@ class Bytes(Fuzzable):
     ]
 
     def __init__(self, name=None, default_value=b"", size=None, padding=b"\x00", max_len=None, *args, **kwargs):
+        if not isinstance(default_value, bytes):
+            raise TypeError("default_value must be bytes type")
+        if not isinstance(padding, bytes):
+            raise TypeError("padding must be bytes type")
+
         super(Bytes, self).__init__(name=name, default_value=default_value, *args, **kwargs)
 
         self.size = size


### PR DESCRIPTION
It was possible to mistakenly pass a sting typed default_value or padding to the Bytes primitive resulting in an not obvious TypeError during runtime.
Now there is a type check in the constructor with an obvious message.

Fixes #552