### PR TITLE
Fix init of FuzzableBlock children in Request

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,7 @@ Fixes
 ^^^^^
 - Fixed check for when to enable the web app.
 - Documented the possibility to disable the web app.
+- Correctly initialize all children of a request which inherit from `FuzzableBlock`.
 
 v0.4.0
 ------

--- a/boofuzz/blocks/request.py
+++ b/boofuzz/blocks/request.py
@@ -115,7 +115,7 @@ class Request(FuzzableBlock, Node):
             self.block_stack[-1].push(item)
 
         # add the opened block to the block stack.
-        if isinstance(item, Block) or isinstance(item, Aligned):  # TODO generic check here
+        if isinstance(item, FuzzableBlock):
             self.block_stack.append(item)
 
     def _generate_context_path(self, block_stack):
@@ -145,7 +145,7 @@ class Request(FuzzableBlock, Node):
 
         for item in stack:
             # if the item is a block, step into it and continue looping.
-            if isinstance(item, Block) or isinstance(item, Aligned):  # TODO generic check here
+            if isinstance(item, FuzzableBlock):
                 for stack_item in self.walk(item.stack):
                     yield stack_item
             else:

--- a/boofuzz/blocks/request.py
+++ b/boofuzz/blocks/request.py
@@ -55,7 +55,7 @@ class Request(FuzzableBlock, Node):
 
             if len(block_stack) == 0:
                 self.stack.append(item)
-            if isinstance(item, Block) or isinstance(item, Aligned):  # TODO generic check here
+            if isinstance(item, FuzzableBlock):
                 block_stack.append(item)
                 self._initialize_children(child_nodes=item.stack, block_stack=block_stack)
                 block_stack.pop()


### PR DESCRIPTION
Currently, blocks inheriting from `FuzzableBlock` are not correctly initialized in `Request`.

As `Block` and `Aligned` both inherit from `FuzzableBlock` the isinstance check will still return true with this change.

Fixes #550
@678098 can you confirm that this works?