### PR TITLE
Fix TypeError in `s_binary` initialization

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,10 +14,8 @@ Fixes
 - Fixed check for when to enable the web app.
 - Documented the possibility to disable the web app.
 - Correctly initialize all children of a request which inherit from `FuzzableBlock`.
-
-Fixes
-^^^^^
 - Added type checking for arguments of `Bytes` primitive to prevent incorrect use.
+- Fixed TypeError in `s_binary` initialization.
 
 v0.4.0
 ------

--- a/boofuzz/__init__.py
+++ b/boofuzz/__init__.py
@@ -593,7 +593,7 @@ def s_binary(value, name=None):
 
         value += six.int2byte(int(pair, 16))
 
-    blocks.CURRENT.push(Static(name=name, default_value=parsed, fuzzable=False))
+    blocks.CURRENT.push(Static(name=name, default_value=parsed))
 
 
 def s_delim(value=" ", fuzzable=True, name=None):


### PR DESCRIPTION
Removed redundant `fuzzable` argument. `Static` already sets fuzzable to False.

Fixes #591 