### PR TITLE
Update to make boofuzz more compatible

### DIFF
--- a/boofuzz/sessions.py
+++ b/boofuzz/sessions.py
@@ -443,6 +443,7 @@ class Session(pgraph.Graph):
         restart_callbacks=None,
         restart_threshold=None,
         restart_timeout=None,
+        restart_wait=3,
         pre_send_callbacks=None,
         post_test_case_callbacks=None,
         post_start_target_callbacks=None,
@@ -480,6 +481,7 @@ class Session(pgraph.Graph):
         self.restart_sleep_time = restart_sleep_time
         self.restart_threshold = restart_threshold
         self.restart_timeout = restart_timeout
+        self.restart_wait = restart_wait
         if fuzz_loggers is None:
             fuzz_loggers = []
             if self.console_gui and os.name != "nt":
@@ -1043,8 +1045,8 @@ class Session(pgraph.Graph):
                 self._fuzz_data_logger.log_info("Restarting target process using {}".format(monitor.__class__.__name__))
                 if monitor.restart_target(target=target, fuzz_data_logger=self._fuzz_data_logger, session=self):
                     # TODO: doesn't this belong in the process monitor?
-                    self._fuzz_data_logger.log_info("Giving the process 3 seconds to settle in")
-                    time.sleep(3)
+                    self._fuzz_data_logger.log_info("Giving the process %d seconds to settle in" % self.restart_wait)
+                    time.sleep(self.restart_wait)
                     restarted = True
                     break
 

--- a/process_monitor.py
+++ b/process_monitor.py
@@ -8,28 +8,20 @@ from boofuzz.utils.debugger_thread_simple import DebuggerThreadSimple
 from boofuzz.utils.process_monitor_pedrpc_server import ProcessMonitorPedrpcServer
 
 
-def serve_procmon(port, crash_bin, proc_name, ignore_pid, log_level):
+def serve_procmon(ip, port, crash_bin, proc_name, ignore_pid, log_level):
     with ProcessMonitorPedrpcServer(
-        host="0.0.0.0",
-        port=port,
-        crash_filename=crash_bin,
-        debugger_class=DebuggerThreadSimple,
-        proc_name=proc_name,
-        pid_to_ignore=ignore_pid,
-        level=log_level,
-        coredump_dir=None,
+            host=ip,
+            port=port,
+            crash_filename=crash_bin,
+            debugger_class=DebuggerThreadSimple,
+            proc_name=proc_name,
+            pid_to_ignore=ignore_pid,
+            level=log_level,
+            coredump_dir=None,
     ) as servlet:
         servlet.serve_forever()
 
 
-# app.args.add_argument("-c", "--crash_bin", help='filename to serialize crash bin class to',
-#                       default='boofuzz-crash-bin', metavar='FILENAME')
-# app.args.add_argument("-i", "--ignore_pid", help='PID to ignore when searching for target process', type=int,
-#                       metavar='PID')
-# app.args.add_argument("-l", "--log_level", help='log level: default 1, increase for more verbosity', type=int,
-#                       default=1, metavar='LEVEL')
-# app.args.add_argument("-p", "--proc_name", help='process name to search for and attach to', metavar='NAME')
-# app.args.add_argument("-P", "--port", help='TCP port to bind this agent to', type=int, default=DEFAULT_PROCMON_PORT)
 @click.command()
 @click.option(
     "--crash-bin",
@@ -58,8 +50,9 @@ def serve_procmon(port, crash_bin, proc_name, ignore_pid, log_level):
 )
 @click.option("--proc-name", "--proc_name", "-p", help="process name to search for and attach to", metavar="NAME")
 @click.option("--port", "-P", help="TCP port to bind this agent to", type=int, default=DEFAULT_PROCMON_PORT)
-def go(crash_bin, ignore_pid, log_level, proc_name, port):
-    serve_procmon(port=port, crash_bin=crash_bin, proc_name=proc_name, ignore_pid=ignore_pid, log_level=log_level)
+@click.option("--ip", "-I", help="IP of the computer", type=str)
+def go(crash_bin, ignore_pid, log_level, proc_name, port, ip):
+    serve_procmon(ip, port=port, crash_bin=crash_bin, proc_name=proc_name, ignore_pid=ignore_pid, log_level=log_level)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
I had these 3 issues when using boofuzz:
- I could not change processmonitor.py listening interface
- processmonitor.py was not compatible with Windows, multiple function used in boofuzz were not available for Windows.
- Some processes to fuzz needs a lot of time before starting up, so the hardcoded 3 seconds delay were not sufficient. A parameter "restart_wait" in Session class has been added to solve this issue