### PR TITLE
Remove legacy future/six code, imports and dependencies

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,12 +1,12 @@
 Changelog
 =========
 
-v0.4.2
-------
+Upcoming
+--------
 Features
 ^^^^^^^^
 - Remove six compatibility module
-
+- Remove Python 2 compatibility code
 
 v0.4.1
 ------

--- a/boofuzz/__init__.py
+++ b/boofuzz/__init__.py
@@ -1,10 +1,7 @@
-from __future__ import absolute_import
-
 import functools
 import sys
 
 import six
-from past.builtins import map
 
 from . import blocks, exception, legos, primitives
 from .blocks import Aligned, Block, Checksum, Repeat, Request, REQUESTS, Size

--- a/boofuzz/blocks/block.py
+++ b/boofuzz/blocks/block.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 from ..fuzzable_block import FuzzableBlock
 
 

--- a/boofuzz/blocks/repeat.py
+++ b/boofuzz/blocks/repeat.py
@@ -1,5 +1,3 @@
-from past.builtins import range
-
 from .. import helpers
 from ..fuzzable import Fuzzable
 from ..protocol_session_reference import ProtocolSessionReference
@@ -69,7 +67,7 @@ class Repeat(Fuzzable):
         self.current_reps = min_reps  # current number of repetitions
 
         if self.max_reps is not None and self.request is not None and self.block_name is not None:
-            self._fuzz_library = range(self.min_reps, self.max_reps + 1, self.step)
+            self._fuzz_library = list(range(self.min_reps, self.max_reps + 1, self.step))
 
     def mutations(self, default_value):
         for fuzzed_reps_number in self._fuzz_library:

--- a/boofuzz/cli.py
+++ b/boofuzz/cli.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python
-from __future__ import print_function
-
 import logging
 import shlex
 import time

--- a/boofuzz/connections/base_socket_connection.py
+++ b/boofuzz/connections/base_socket_connection.py
@@ -1,12 +1,8 @@
-from __future__ import absolute_import
-
 import abc
 import math
 import os
 import socket
 import struct
-
-from future.utils import with_metaclass
 
 from boofuzz.connections import itarget_connection
 
@@ -24,7 +20,7 @@ def _seconds_to_sockopt_format(seconds):
         return struct.pack("ll", whole_seconds, whole_microseconds)
 
 
-class BaseSocketConnection(with_metaclass(abc.ABCMeta, itarget_connection.ITargetConnection)):
+class BaseSocketConnection(itarget_connection.ITargetConnection, metaclass=abc.ABCMeta):
     """This class serves as a base for a number of Connections over sockets.
 
     .. versionadded:: 0.2.0

--- a/boofuzz/connections/file_connection.py
+++ b/boofuzz/connections/file_connection.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import errno
 import os
 

--- a/boofuzz/connections/iserial_like.py
+++ b/boofuzz/connections/iserial_like.py
@@ -1,10 +1,8 @@
 import abc
 
-from future.utils import with_metaclass
-
 
 # abc.ABCMeta is the metaclass in both python 2 and 3
-class ISerialLike(with_metaclass(abc.ABCMeta, object)):
+class ISerialLike(metaclass=abc.ABCMeta):
     """
     A serial-like interface, based on the pySerial module,
     the notable difference being that open() must always be called after the object is first created.

--- a/boofuzz/connections/itarget_connection.py
+++ b/boofuzz/connections/itarget_connection.py
@@ -1,10 +1,8 @@
 import abc
 
-from future.utils import with_metaclass
-
 
 # abc.ABCMeta is the metaclass in both python 2 and 3
-class ITargetConnection(with_metaclass(abc.ABCMeta, object)):
+class ITargetConnection(metaclass=abc.ABCMeta):
     """
     Interface for connections to fuzzing targets.
     Target connections may be opened and closed multiple times. You must open before using send/recv and close

--- a/boofuzz/connections/raw_l2_socket_connection.py
+++ b/boofuzz/connections/raw_l2_socket_connection.py
@@ -1,10 +1,6 @@
-from __future__ import absolute_import
-
 import errno
 import socket
 import sys
-
-from future.utils import raise_
 
 from boofuzz import exception
 from boofuzz.connections import base_socket_connection
@@ -81,13 +77,11 @@ class RawL2SocketConnection(base_socket_connection.BaseSocketConnection):
             data = b""
         except socket.error as e:
             if e.errno == errno.ECONNABORTED:
-                raise_(
-                    exception.BoofuzzTargetConnectionAborted(socket_errno=e.errno, socket_errmsg=e.strerror),
-                    None,
-                    sys.exc_info()[2],
-                )
+                raise exception.BoofuzzTargetConnectionAborted(
+                    socket_errno=e.errno, socket_errmsg=e.strerror
+                ).with_traceback(sys.exc_info()[2])
             elif e.errno in [errno.ECONNRESET, errno.ENETRESET, errno.ETIMEDOUT]:
-                raise_(exception.BoofuzzTargetConnectionReset(), None, sys.exc_info()[2])
+                raise exception.BoofuzzTargetConnectionReset().with_traceback(sys.exc_info()[2])
             elif e.errno == errno.EWOULDBLOCK:
                 data = b""
             else:
@@ -116,13 +110,11 @@ class RawL2SocketConnection(base_socket_connection.BaseSocketConnection):
 
         except socket.error as e:
             if e.errno == errno.ECONNABORTED:
-                raise_(
-                    exception.BoofuzzTargetConnectionAborted(socket_errno=e.errno, socket_errmsg=e.strerror),
-                    None,
-                    sys.exc_info()[2],
-                )
+                raise exception.BoofuzzTargetConnectionAborted(
+                    socket_errno=e.errno, socket_errmsg=e.strerror
+                ).with_traceback(sys.exc_info()[2])
             elif e.errno in [errno.ECONNRESET, errno.ENETRESET, errno.ETIMEDOUT, errno.EPIPE]:
-                raise_(exception.BoofuzzTargetConnectionReset(), None, sys.exc_info()[2])
+                raise exception.BoofuzzTargetConnectionReset().with_traceback(sys.exc_info()[2])
             else:
                 raise
 

--- a/boofuzz/connections/raw_l3_socket_connection.py
+++ b/boofuzz/connections/raw_l3_socket_connection.py
@@ -1,10 +1,6 @@
-from __future__ import absolute_import
-
 import errno
 import socket
 import sys
-
-from future.utils import raise_
 
 from boofuzz import exception
 from boofuzz.connections import base_socket_connection
@@ -68,19 +64,17 @@ class RawL3SocketConnection(base_socket_connection.BaseSocketConnection):
             data = self._sock.recv(self.packet_size)
 
             if 0 < max_bytes < self.packet_size:
-                data = data[: self._packet_size]
+                data = data[: self.packet_size]
 
         except socket.timeout:
             data = b""
         except socket.error as e:
             if e.errno == errno.ECONNABORTED:
-                raise_(
-                    exception.BoofuzzTargetConnectionAborted(socket_errno=e.errno, socket_errmsg=e.strerror),
-                    None,
-                    sys.exc_info()[2],
-                )
+                raise exception.BoofuzzTargetConnectionAborted(
+                    socket_errno=e.errno, socket_errmsg=e.strerror
+                ).with_traceback(sys.exc_info()[2])
             elif e.errno in [errno.ECONNRESET, errno.ENETRESET, errno.ETIMEDOUT]:
-                raise_(exception.BoofuzzTargetConnectionReset(), None, sys.exc_info()[2])
+                raise exception.BoofuzzTargetConnectionReset().with_traceback(sys.exc_info()[2])
             elif e.errno == errno.EWOULDBLOCK:
                 data = b""
             else:
@@ -109,13 +103,11 @@ class RawL3SocketConnection(base_socket_connection.BaseSocketConnection):
 
         except socket.error as e:
             if e.errno == errno.ECONNABORTED:
-                raise_(
-                    exception.BoofuzzTargetConnectionAborted(socket_errno=e.errno, socket_errmsg=e.strerror),
-                    None,
-                    sys.exc_info()[2],
-                )
+                raise exception.BoofuzzTargetConnectionAborted(
+                    socket_errno=e.errno, socket_errmsg=e.strerror
+                ).with_traceback(sys.exc_info()[2])
             elif e.errno in [errno.ECONNRESET, errno.ENETRESET, errno.ETIMEDOUT, errno.EPIPE]:
-                raise_(exception.BoofuzzTargetConnectionReset(), None, sys.exc_info()[2])
+                raise exception.BoofuzzTargetConnectionReset().with_traceback(sys.exc_info()[2])
             else:
                 raise
 

--- a/boofuzz/connections/serial_connection.py
+++ b/boofuzz/connections/serial_connection.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import time
 
 from boofuzz.connections import itarget_connection, serial_connection_low_level

--- a/boofuzz/connections/socket_connection.py
+++ b/boofuzz/connections/socket_connection.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import
-
 import warnings
 
 from boofuzz import exception

--- a/boofuzz/connections/ssl_socket_connection.py
+++ b/boofuzz/connections/ssl_socket_connection.py
@@ -1,8 +1,4 @@
-from __future__ import absolute_import
-
 import ssl
-
-from future.utils import raise_
 
 from boofuzz import exception
 from boofuzz.connections import tcp_socket_connection
@@ -77,7 +73,7 @@ class SSLSocketConnection(tcp_socket_connection.TCPSocketConnection):
         except ssl.SSLError as e:
             # If an SSL error is thrown the connection should be treated as lost
             # All other exceptions should be handled / raised / re-raised by the parent class.
-            raise_(exception.BoofuzzSSLError(str(e)))
+            raise exception.BoofuzzSSLError(str(e))
 
         return data
 
@@ -99,6 +95,6 @@ class SSLSocketConnection(tcp_socket_connection.TCPSocketConnection):
             except ssl.SSLError as e:
                 # If an SSL error is thrown the connection should be treated as lost.
                 # All other exceptions should be handled / raised / re-raised by the parent class.
-                raise_(exception.BoofuzzSSLError(str(e)))
+                raise exception.BoofuzzSSLError(str(e))
 
         return num_sent

--- a/boofuzz/connections/tcp_socket_connection.py
+++ b/boofuzz/connections/tcp_socket_connection.py
@@ -1,10 +1,6 @@
-from __future__ import absolute_import
-
 import errno
 import socket
 import sys
-
-from future.utils import raise_
 
 from boofuzz import exception
 from boofuzz.connections import base_socket_connection
@@ -100,13 +96,11 @@ class TCPSocketConnection(base_socket_connection.BaseSocketConnection):
             data = b""
         except socket.error as e:
             if e.errno == errno.ECONNABORTED:
-                raise_(
-                    exception.BoofuzzTargetConnectionAborted(socket_errno=e.errno, socket_errmsg=e.strerror),
-                    None,
-                    sys.exc_info()[2],
-                )
+                raise exception.BoofuzzTargetConnectionAborted(
+                    socket_errno=e.errno, socket_errmsg=e.strerror
+                ).with_traceback(sys.exc_info()[2])
             elif (e.errno == errno.ECONNRESET) or (e.errno == errno.ENETRESET) or (e.errno == errno.ETIMEDOUT):
-                raise_(exception.BoofuzzTargetConnectionReset(), None, sys.exc_info()[2])
+                raise exception.BoofuzzTargetConnectionReset().with_traceback(sys.exc_info()[2])
             elif e.errno == errno.EWOULDBLOCK:  # timeout condition if using SO_RCVTIMEO or SO_SNDTIMEO
                 data = b""
             else:
@@ -130,13 +124,11 @@ class TCPSocketConnection(base_socket_connection.BaseSocketConnection):
             num_sent = self._sock.send(data)
         except socket.error as e:
             if e.errno == errno.ECONNABORTED:
-                raise_(
-                    exception.BoofuzzTargetConnectionAborted(socket_errno=e.errno, socket_errmsg=e.strerror),
-                    None,
-                    sys.exc_info()[2],
-                )
+                raise exception.BoofuzzTargetConnectionAborted(
+                    socket_errno=e.errno, socket_errmsg=e.strerror
+                ).with_traceback(sys.exc_info()[2])
             elif e.errno in [errno.ECONNRESET, errno.ENETRESET, errno.ETIMEDOUT, errno.EPIPE]:
-                raise_(exception.BoofuzzTargetConnectionReset(), None, sys.exc_info()[2])
+                raise exception.BoofuzzTargetConnectionReset().with_traceback(sys.exc_info()[2])
             else:
                 raise
 

--- a/boofuzz/connections/udp_socket_connection.py
+++ b/boofuzz/connections/udp_socket_connection.py
@@ -1,12 +1,8 @@
-from __future__ import absolute_import
-
 import ctypes
 import errno
 import platform
 import socket
 import sys
-
-from future.utils import raise_
 
 from boofuzz import exception
 from boofuzz.connections import base_socket_connection, ip_constants
@@ -90,13 +86,11 @@ class UDPSocketConnection(base_socket_connection.BaseSocketConnection):
             data = b""
         except socket.error as e:
             if e.errno == errno.ECONNABORTED:
-                raise_(
-                    exception.BoofuzzTargetConnectionAborted(socket_errno=e.errno, socket_errmsg=e.strerror),
-                    None,
-                    sys.exc_info()[2],
-                )
+                raise exception.BoofuzzTargetConnectionAborted(
+                    socket_errno=e.errno, socket_errmsg=e.strerror
+                ).with_traceback(sys.exc_info()[2])
             elif e.errno in [errno.ECONNRESET, errno.ENETRESET, errno.ETIMEDOUT]:
-                raise_(exception.BoofuzzTargetConnectionReset(), None, sys.exc_info()[2])
+                raise exception.BoofuzzTargetConnectionReset().with_traceback(sys.exc_info()[2])
             elif e.errno == errno.EWOULDBLOCK:
                 data = b""
             else:
@@ -128,13 +122,11 @@ class UDPSocketConnection(base_socket_connection.BaseSocketConnection):
                 num_sent = self._sock.sendto(data, (self.host, self.port))
         except socket.error as e:
             if e.errno == errno.ECONNABORTED:
-                raise_(
-                    exception.BoofuzzTargetConnectionAborted(socket_errno=e.errno, socket_errmsg=e.strerror),
-                    None,
-                    sys.exc_info()[2],
-                )
+                raise exception.BoofuzzTargetConnectionAborted(
+                    socket_errno=e.errno, socket_errmsg=e.strerror
+                ).with_traceback(sys.exc_info()[2])
             elif e.errno in [errno.ECONNRESET, errno.ENETRESET, errno.ETIMEDOUT, errno.EPIPE]:
-                raise_(exception.BoofuzzTargetConnectionReset(), None, sys.exc_info()[2])
+                raise exception.BoofuzzTargetConnectionReset().with_traceback(sys.exc_info()[2])
             else:
                 raise
 

--- a/boofuzz/connections/unix_socket_connection.py
+++ b/boofuzz/connections/unix_socket_connection.py
@@ -1,10 +1,6 @@
-from __future__ import absolute_import
-
 import errno
 import socket
 import sys
-
-from future.utils import raise_
 
 from boofuzz import exception
 from boofuzz.connections import base_socket_connection
@@ -67,13 +63,11 @@ class UnixSocketConnection(base_socket_connection.BaseSocketConnection):
             data = b""
         except socket.error as e:
             if e.errno == errno.ECONNABORTED:
-                raise_(
-                    exception.BoofuzzTargetConnectionAborted(socket_errno=e.errno, socket_errmsg=e.strerror),
-                    None,
-                    sys.exc_info()[2],
-                )
+                raise exception.BoofuzzTargetConnectionAborted(
+                    socket_errno=e.errno, socket_errmsg=e.strerror
+                ).with_traceback(sys.exc_info()[2])
             elif (e.errno == errno.ECONNRESET) or (e.errno == errno.ENETRESET) or (e.errno == errno.ETIMEDOUT):
-                raise_(exception.BoofuzzTargetConnectionReset(), None, sys.exc_info()[2])
+                raise exception.BoofuzzTargetConnectionReset().with_traceback(sys.exc_info()[2])
             elif e.errno == errno.EWOULDBLOCK:  # timeout condition if using SO_RCVTIMEO or SO_SNDTIMEO
                 data = b""
             else:
@@ -97,13 +91,11 @@ class UnixSocketConnection(base_socket_connection.BaseSocketConnection):
             num_sent = self._sock.send(data)
         except socket.error as e:
             if e.errno == errno.ECONNABORTED:
-                raise_(
-                    exception.BoofuzzTargetConnectionAborted(socket_errno=e.errno, socket_errmsg=e.strerror),
-                    None,
-                    sys.exc_info()[2],
-                )
+                raise exception.BoofuzzTargetConnectionAborted(
+                    socket_errno=e.errno, socket_errmsg=e.strerror
+                ).with_traceback(sys.exc_info()[2])
             elif e.errno in [errno.ECONNRESET, errno.ENETRESET, errno.ETIMEDOUT, errno.EPIPE]:
-                raise_(exception.BoofuzzTargetConnectionReset(), None, sys.exc_info()[2])
+                raise exception.BoofuzzTargetConnectionReset().with_traceback(sys.exc_info()[2])
             else:
                 raise
 

--- a/boofuzz/data_test_case.py
+++ b/boofuzz/data_test_case.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import attr
 
 from . import helpers

--- a/boofuzz/data_test_step.py
+++ b/boofuzz/data_test_step.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import attr
 
 from . import helpers

--- a/boofuzz/fuzz_logger.py
+++ b/boofuzz/fuzz_logger.py
@@ -1,7 +1,5 @@
 from typing import Union  # noqa: F401
 
-from past.builtins import map
-
 from .ifuzz_logger import IFuzzLogger
 
 

--- a/boofuzz/fuzz_logger_csv.py
+++ b/boofuzz/fuzz_logger_csv.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import csv
 import datetime
 import sys

--- a/boofuzz/fuzz_logger_curses.py
+++ b/boofuzz/fuzz_logger_curses.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import atexit
 import sys
 import time

--- a/boofuzz/fuzz_logger_db.py
+++ b/boofuzz/fuzz_logger_db.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import collections
 import datetime
 import sqlite3

--- a/boofuzz/fuzz_logger_text.py
+++ b/boofuzz/fuzz_logger_text.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import sys
 
 from colorama import init

--- a/boofuzz/fuzzable.py
+++ b/boofuzz/fuzzable.py
@@ -1,12 +1,11 @@
-from future.builtins import object
-from future.moves import itertools
+import itertools
 
 from boofuzz.mutation import Mutation
 from .mutation_context import MutationContext
 from .protocol_session_reference import ProtocolSessionReference
 
 
-class Fuzzable(object):
+class Fuzzable:
     """Parent class for all primitives and blocks.
 
     When making new fuzzable types, one will typically override :meth:`mutations` and/or :meth:`encode`.

--- a/boofuzz/helpers.py
+++ b/boofuzz/helpers.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import errno
 import os
 import re
@@ -14,7 +12,6 @@ from functools import reduce
 
 import six
 from colorama import Back, Fore, Style
-from past.builtins import map, range
 
 from boofuzz.connections import ip_constants, udp_socket_connection
 from boofuzz.exception import BoofuzzError

--- a/boofuzz/ifuzz_logger.py
+++ b/boofuzz/ifuzz_logger.py
@@ -1,10 +1,8 @@
 import abc
 
-from future.utils import with_metaclass
-
 
 # abc.ABCMeta is the metaclass in both python 2 and 3
-class IFuzzLogger(with_metaclass(abc.ABCMeta, object)):
+class IFuzzLogger(metaclass=abc.ABCMeta):
     """
     Abstract class for logging fuzz data.
 

--- a/boofuzz/legos/ber.py
+++ b/boofuzz/legos/ber.py
@@ -1,7 +1,5 @@
 # ASN.1 / BER TYPES (http://luca.ntop.org/Teaching/Appunti/asn1.html)
 
-from __future__ import absolute_import
-
 from .. import blocks, exception, helpers, primitives
 from ..constants import BIG_ENDIAN
 

--- a/boofuzz/legos/misc.py
+++ b/boofuzz/legos/misc.py
@@ -1,6 +1,4 @@
 # Misc Types
-from __future__ import absolute_import
-
 from .. import blocks, exception, helpers, primitives
 
 

--- a/boofuzz/legos/xdr.py
+++ b/boofuzz/legos/xdr.py
@@ -1,7 +1,5 @@
 # XDR TYPES (http://www.freesoft.org/CIE/RFC/1832/index.htm)
 
-from __future__ import absolute_import
-
 import struct
 
 from .. import blocks, exception, helpers, primitives

--- a/boofuzz/pgraph/graph.py
+++ b/boofuzz/pgraph/graph.py
@@ -16,11 +16,9 @@
 import copy
 
 import pydot
-from builtins import object
-from future.utils import listvalues
 
 
-class Graph(object):
+class Graph:
     """
     @todo: Add support for clusters
     @todo: Potentially swap node list with a node dictionary for increased performance
@@ -176,7 +174,7 @@ class Graph(object):
         @return: List of edges from the specified node
         """
 
-        return [edge_value for edge_value in listvalues(self.edges) if edge_value.src == edge_id]
+        return [edge_value for edge_value in list(self.edges.values()) if edge_value.src == edge_id]
 
     def edges_to(self, edge_id):
         """
@@ -189,7 +187,7 @@ class Graph(object):
         @return: List of edges to the specified node
         """
 
-        return [edge_value for edge_value in listvalues(self.edges) if edge_value.dst == edge_id]
+        return [edge_value for edge_value in list(self.edges.values()) if edge_value.dst == edge_id]
 
     def find_cluster(self, attribute, value):
         """
@@ -252,7 +250,7 @@ class Graph(object):
         # step through all the edges looking for the given attribute/value pair.
         else:
             # TODO: Verify that this actually works? Was broken when I got here ;-P
-            for node_edge in listvalues(self.edges):
+            for node_edge in list(self.edges.values()):
                 if hasattr(node_edge, attribute):
                     if getattr(node_edge, attribute) == value:
                         return node_edge
@@ -278,7 +276,7 @@ class Graph(object):
 
         # step through all the nodes looking for the given attribute/value pair.
         else:
-            for node in listvalues(self.nodes):
+            for node in list(self.nodes.values()):
                 if hasattr(node, attribute):
                     if getattr(node, attribute) == value:
                         return node
@@ -295,10 +293,10 @@ class Graph(object):
         @param other_graph: Graph to concatenate into this one.
         """
 
-        for other_node in listvalues(other_graph.nodes):
+        for other_node in list(other_graph.nodes.values()):
             self.add_node(other_node)
 
-        for other_edge in listvalues(other_graph.edges):
+        for other_edge in list(other_graph.edges.values()):
             self.add_edge(other_edge)
 
         return self
@@ -364,11 +362,11 @@ class Graph(object):
         @param other_graph: Graph to intersect with
         """
 
-        for node in listvalues(self.nodes):
+        for node in list(self.nodes.values()):
             if not other_graph.find_node("id", node.id):
                 self.del_node(node.id)
 
-        for edge in listvalues(self.edges):
+        for edge in list(self.edges.values()):
             if not other_graph.find_edge("id", edge.id):
                 self.del_edge(edge.id)
 
@@ -405,10 +403,10 @@ class Graph(object):
         @param other_graph: Graph to diff/remove against
         """
 
-        for other_node in listvalues(other_graph.nodes):
+        for other_node in list(other_graph.nodes.values()):
             self.del_node(other_node.id)
 
-        for other_edge in listvalues(other_graph.edges):
+        for other_edge in list(other_graph.edges.values()):
             self.del_edge(None, other_edge.src, other_edge.dst)
 
         return self
@@ -475,11 +473,11 @@ class Graph(object):
         gml += "graph [\n"
 
         # add the nodes to the GML definition.
-        for node in listvalues(self.nodes):
+        for node in list(self.nodes.values()):
             gml += node.render_node_gml()
 
         # add the edges to the GML definition.
-        for edge in listvalues(self.edges):
+        for edge in list(self.edges.values()):
             gml += edge.render_edge_gml(self)
 
         # close the graph tag.
@@ -523,10 +521,10 @@ class Graph(object):
         """
         dot_graph = pydot.Dot()
 
-        for node in listvalues(self.nodes):
+        for node in list(self.nodes.values()):
             dot_graph.add_node(node.render_node_graphviz())
 
-        for edge in listvalues(self.edges):
+        for edge in list(self.edges.values()):
             dot_graph.add_edge(edge.render_edge_graphviz())
 
         return dot_graph
@@ -543,7 +541,7 @@ class Graph(object):
 
         # render each of the nodes in the graph.
         # the individual nodes will handle their own edge rendering.
-        for node in listvalues(self.nodes):
+        for node in list(self.nodes.values()):
             udraw += node.render_node_udraw(self)
             udraw += ","
 
@@ -562,11 +560,11 @@ class Graph(object):
 
         udraw = "["
 
-        for node in listvalues(self.nodes):
+        for node in list(self.nodes.values()):
             udraw += node.render_node_udraw_update()
             udraw += ","
 
-        for edge in listvalues(self.edges):
+        for edge in list(self.edges.values()):
             udraw += edge.render_edge_udraw_update()
             udraw += ","
 
@@ -596,7 +594,7 @@ class Graph(object):
         self.nodes[node.id] = node
 
         # update the edges.
-        for edge in [edge for edge in listvalues(self.edges) if current_id in (edge.src, edge.dst)]:
+        for edge in [edge for edge in list(self.edges.values()) if current_id in (edge.src, edge.dst)]:
             del self.edges[edge.id]
 
             if edge.src == current_id:

--- a/boofuzz/pgraph/node.py
+++ b/boofuzz/pgraph/node.py
@@ -14,10 +14,9 @@
 #
 
 import pydot
-from future.builtins import object
 
 
-class Node(object):
+class Node:
     id = 0
     number = 0
 

--- a/boofuzz/primitives/bit_field.py
+++ b/boofuzz/primitives/bit_field.py
@@ -1,8 +1,6 @@
 import struct
-from builtins import range
 
 import six
-from past.builtins import map
 
 from .. import helpers
 from ..constants import LITTLE_ENDIAN

--- a/boofuzz/primitives/random_data.py
+++ b/boofuzz/primitives/random_data.py
@@ -1,8 +1,6 @@
 import random
 import struct
 
-from past.builtins import xrange
-
 from boofuzz import helpers
 from ..fuzzable import Fuzzable
 
@@ -66,7 +64,7 @@ class RandomData(Fuzzable):
                 length = self.min_length + i * self.step
 
             value = b""
-            for _ in xrange(length):
+            for _ in range(length):
                 value += struct.pack("B", local_random.randint(0, 255))
             yield value
 

--- a/boofuzz/primitives/string.py
+++ b/boofuzz/primitives/string.py
@@ -1,16 +1,11 @@
-from __future__ import division
-
 import itertools
 import math
 import random
 
 import six
-from future.standard_library import install_aliases
 from six.moves import range
 
 from ..fuzzable import Fuzzable
-
-install_aliases()
 
 
 class String(Fuzzable):

--- a/boofuzz/sessions.py
+++ b/boofuzz/sessions.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, print_function
-
 import datetime
 import errno
 import itertools

--- a/boofuzz/utils/crash_binning.py
+++ b/boofuzz/utils/crash_binning.py
@@ -25,8 +25,6 @@
 import json
 from io import open
 
-from past.builtins import xrange
-
 
 class CrashBinStruct:
     def __init__(self):
@@ -96,7 +94,7 @@ class CrashBinning:
         crash.extra = extra
 
         # add module names to the stack unwind.
-        for i in xrange(len(crash.stack_unwind)):
+        for i in range(len(crash.stack_unwind)):
             addr = crash.stack_unwind[i]
             module = pydbg.addr_to_module(addr)
 
@@ -108,7 +106,7 @@ class CrashBinning:
             crash.stack_unwind[i] = "%s:%08x" % (module, addr)
 
         # add module names to the SEH unwind.
-        for i in xrange(len(crash.seh_unwind)):
+        for i in range(len(crash.seh_unwind)):
             (addr, handler) = crash.seh_unwind[i]
 
             module = pydbg.addr_to_module(handler)

--- a/boofuzz/utils/dcerpc.py
+++ b/boofuzz/utils/dcerpc.py
@@ -1,9 +1,5 @@
-from __future__ import absolute_import
-
 import math
 import struct
-
-from past.builtins import xrange
 
 from .. import helpers
 
@@ -70,7 +66,7 @@ def request(opnum, data):
 
     num_frags = int(math.ceil(float(len(data)) / float(frag_size)))
 
-    for i in xrange(num_frags):
+    for i in range(num_frags):
         chunk = data[i * frag_size : (i + 1) * frag_size]
         frag_length = struct.pack("<H", len(chunk) + 24)
         alloc_hint = struct.pack("<L", len(chunk))

--- a/boofuzz/utils/debugger_thread_pydbg.py
+++ b/boofuzz/utils/debugger_thread_pydbg.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import os
 import subprocess
 import sys

--- a/boofuzz/utils/debugger_thread_simple.py
+++ b/boofuzz/utils/debugger_thread_simple.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 import os
 
 try:

--- a/boofuzz/utils/process_monitor_local.py
+++ b/boofuzz/utils/process_monitor_local.py
@@ -1,12 +1,8 @@
-from __future__ import print_function
-
 import os
 import shlex
 import subprocess
 import time
 from builtins import str
-
-from past.builtins import map
 
 from boofuzz import utils
 from boofuzz.monitors.base_monitor import BaseMonitor
@@ -234,12 +230,12 @@ class ProcessMonitorLocal(BaseMonitor):
 
     def set_start_commands(self, new_start_commands):
         self.log("updating start commands to: {0}".format(list(new_start_commands)))
-        self.start_commands = map(_split_command_if_str, new_start_commands)
+        self.start_commands = list(map(_split_command_if_str, new_start_commands))
 
     def set_stop_commands(self, new_stop_commands):
         self.log("updating stop commands to: {0}".format(list(new_stop_commands)))
         self.stop_commands = new_stop_commands
-        self.stop_commands = map(_split_command_if_str, new_stop_commands)
+        self.stop_commands = list(map(_split_command_if_str, new_stop_commands))
 
     def set_crash_filename(self, new_crash_filename):
         self.log("updating crash bin filename to '%s'" % new_crash_filename)

--- a/boofuzz/utils/process_monitor_pedrpc_server.py
+++ b/boofuzz/utils/process_monitor_pedrpc_server.py
@@ -1,12 +1,8 @@
-from __future__ import print_function
-
 import os
 import shlex
 import subprocess
 import time
 from builtins import str
-
-from past.builtins import map
 
 from boofuzz import pedrpc, utils
 
@@ -235,12 +231,12 @@ class ProcessMonitorPedrpcServer(pedrpc.Server):
 
     def set_start_commands(self, new_start_commands):
         self.log("updating start commands to: {0}".format(list(new_start_commands)))
-        self.start_commands = map(_split_command_if_str, new_start_commands)
+        self.start_commands = list(map(_split_command_if_str, new_start_commands))
 
     def set_stop_commands(self, new_stop_commands):
         self.log("updating stop commands to: {0}".format(list(new_stop_commands)))
         self.stop_commands = new_stop_commands
-        self.stop_commands = map(_split_command_if_str, new_stop_commands)
+        self.stop_commands = list(map(_split_command_if_str, new_stop_commands))
 
     def set_crash_filename(self, new_crash_filename):
         self.log("updating crash bin filename to '%s'" % new_crash_filename)

--- a/boofuzz/utils/scada.py
+++ b/boofuzz/utils/scada.py
@@ -1,10 +1,7 @@
-from __future__ import absolute_import
-
 import math
 import struct
 
 import six
-from past.builtins import xrange
 
 from ..helpers import crc16
 
@@ -13,7 +10,7 @@ def dnp3(data, control_code=b"\x44", src=b"\x00\x00", dst=b"\x00\x00"):
     num_packets = int(math.ceil(float(len(data)) / 250.0))
     packets = []
 
-    for i in xrange(num_packets):
+    for i in range(num_packets):
         packet_slice = data[i * 250 : (i + 1) * 250]
 
         p = b"\x05\x64"
@@ -41,7 +38,7 @@ def dnp3(data, control_code=b"\x44", src=b"\x00\x00", dst=b"\x00\x00"):
 
         p += six.int2byte(frag_number)
 
-        for x in xrange(num_chunks):
+        for x in range(num_chunks):
             chunk = packet_slice[i * 16 : (i + 1) * 16]
             chksum = struct.pack("<H", crc16(chunk))
             p += chksum + chunk

--- a/process_monitor.py
+++ b/process_monitor.py
@@ -1,6 +1,4 @@
 #!c:\\python\\python.exe
-from __future__ import print_function
-
 import click
 
 from boofuzz.constants import DEFAULT_PROCMON_PORT

--- a/request_definitions/trend.py
+++ b/request_definitions/trend.py
@@ -1,7 +1,5 @@
 import struct
 
-from past.builtins import range
-
 from boofuzz import *
 from boofuzz import utils
 

--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,6 @@ setup(
         "colorama",
         "Flask",
         "funcy",
-        "future",
         "psutil",
         "pyserial",
         "pydot",

--- a/unit_tests/test_fuzz_logger_text.py
+++ b/unit_tests/test_fuzz_logger_text.py
@@ -1,5 +1,3 @@
-from __future__ import absolute_import, unicode_literals
-
 import unittest
 from builtins import bytes, chr
 from io import StringIO

--- a/unit_tests/test_helpers_udp_checksum.py
+++ b/unit_tests/test_helpers_udp_checksum.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import ast
 import math
 

--- a/unit_tests/test_monitors.py
+++ b/unit_tests/test_monitors.py
@@ -1,4 +1,3 @@
-import sys
 import time
 import unittest
 from multiprocessing import Process
@@ -58,10 +57,6 @@ def _start_rpc(server):
     server.serve_forever()
 
 
-# https://github.com/jtpereyda/boofuzz/pull/409
-@unittest.skipIf(
-    sys.platform.startswith("win") and sys.version_info.major == 2, "Multithreading problem on Python2 Windows"
-)
 class TestProcessMonitor(unittest.TestCase):
     def setUp(self):
         self.rpc_server = MockRPCServer(RPC_HOST, RPC_PORT)
@@ -109,10 +104,6 @@ class TestProcessMonitor(unittest.TestCase):
         self.assertEqual(self.process_monitor.get_foobar(), "bazbar")
 
 
-# https://github.com/jtpereyda/boofuzz/pull/409
-@unittest.skipIf(
-    sys.platform.startswith("win") and sys.version_info.major == 2, "Multithreading problem on Python2 Windows"
-)
 class TestNetworkMonitor(unittest.TestCase):
     def setUp(self):
         self.rpc_server = MockRPCServer(RPC_HOST, RPC_PORT)

--- a/unit_tests/test_primitives.py
+++ b/unit_tests/test_primitives.py
@@ -3,7 +3,6 @@ import shutil
 import unittest
 
 import pytest
-from past.builtins import xrange
 
 from boofuzz import *
 
@@ -67,7 +66,7 @@ class TestPrimitives(unittest.TestCase):
 
         # check that string padding and truncation are working correctly.
         mutations_generator = req.get_mutations()
-        for i in xrange(0, 50):
+        for i in range(0, 50):
             next(mutations_generator)
             self.assertEqual(
                 len(req.resolve_name(context_path="STRING UNIT TEST 1", name="sized_string").render()), 200
@@ -91,7 +90,7 @@ class TestPrimitives(unittest.TestCase):
 
         req = s_get("test_s_mirror")
         mutations_generator = req.get_mutations()
-        for _ in xrange(len(test_group_values)):
+        for _ in range(len(test_group_values)):
             next(mutations_generator)
             group_start_value = req.resolve_name(context_path="test_s_mirror", name="group_start").render()
             self.assertEqual(

--- a/unit_tests/test_string.py
+++ b/unit_tests/test_string.py
@@ -1,5 +1,3 @@
-from __future__ import division
-
 import itertools
 import math
 import unittest
@@ -7,12 +5,9 @@ from collections import Counter, OrderedDict
 
 import pytest
 import six
-from future.standard_library import install_aliases
 from six.moves import map, zip
 
 from boofuzz import *
-
-install_aliases()
 
 
 @pytest.fixture(autouse=True)

--- a/utils/crashbin_explorer.py
+++ b/utils/crashbin_explorer.py
@@ -4,8 +4,6 @@ import sys
 from builtins import int
 from io import open
 
-from future.utils import iteritems
-
 from boofuzz import pgraph, utils
 
 sys.path.append(r"../../../paimei")
@@ -50,7 +48,7 @@ except Exception:
 #
 
 if test_number:
-    for _, crashes in iteritems(crashbin.bins):
+    for crashes in crashbin.bins.values():
         for crash in crashes:
             if test_number == crash.extra:
                 print(crashbin.crash_synopsis(crash))
@@ -64,7 +62,7 @@ if graph_name:
     graph = pgraph.Graph()
 
 # noinspection PyRedeclaration
-for _, crashes in iteritems(crashbin.bins):
+for crashes in crashbin.bins.values():
     synopsis = crashbin.crash_synopsis(crashes[0]).split("\n")[0]
 
     for crash in crashes:

--- a/utils/pcap_cleaner.py
+++ b/utils/pcap_cleaner.py
@@ -3,8 +3,6 @@
 import os
 import sys
 
-from future.utils import iteritems
-
 from boofuzz import utils
 
 sys.path.append(r"..\..\..\paimei")
@@ -29,7 +27,7 @@ except Exception:
     sys.exit(1)
 
 test_cases = []
-for _, crashes in iteritems(crashbin.bins):
+for crashes in crashbin.bins.values():
     for crash in crashes:
         test_cases.append("%d.pcap" % crash.extra)
 

--- a/utils/pdml_parser.py
+++ b/utils/pdml_parser.py
@@ -1,7 +1,5 @@
 #!c:\python\python.exe
 
-from __future__ import print_function
-
 import sys
 from xml.sax import ContentHandler, make_parser
 from xml.sax.handler import feature_namespaces

--- a/vmcontrol.py
+++ b/vmcontrol.py
@@ -1,7 +1,5 @@
 #!/usr/bin/python
 #!c:\\python\\python.exe  # noqa: E265
-from __future__ import print_function
-
 import getopt
 import os
 import sys


### PR DESCRIPTION
Remove unused code and dependencies for Python 2 backwards compatibility.

Code will be easier to read and possibly more performant. Plus we will have less packet dependencies.

TODO:
- [x] remove future/past
- [x] remove six (done in #603)
- [x] changelog entry