### PR TITLE
Use file encoding write

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+Fixes
+^^^^^
+- Specified encoding on file write rather than assuming default encoding
+
 v0.4.1
 ------
 Features

--- a/boofuzz/utils/debugger_thread_simple.py
+++ b/boofuzz/utils/debugger_thread_simple.py
@@ -230,7 +230,7 @@ class DebuggerThreadSimple(threading.Thread):
         if self.is_alive():
             return True
         else:
-            with open(self.process_monitor.crash_filename, "a") as rec_file:
+            with open(self.process_monitor.crash_filename, "a", encoding="utf-8") as rec_file:
                 rec_file.write(self.process_monitor.last_synopsis)
 
             if self.process_monitor.coredump_dir is not None:

--- a/unit_tests/test_primitives.py
+++ b/unit_tests/test_primitives.py
@@ -158,11 +158,11 @@ class TestPrimitives(unittest.TestCase):
             pass
 
         # create extension libraries for unit test.
-        with open(fuzz_strings_path, "w") as fh:
+        with open(fuzz_strings_path, "w", encoding="utf-8") as fh:
             fh.write("pedram\n")
             fh.write("amini\n")
 
-        with open(fuzz_ints_path, "w") as fh:
+        with open(fuzz_ints_path, "w", encoding="utf-8") as fh:
             fh.write("deadbeef\n")
             fh.write("0xc0cac01a\n")
 

--- a/utils/crashbin_explorer.py
+++ b/utils/crashbin_explorer.py
@@ -97,6 +97,6 @@ for _, crashes in iteritems(crashbin.bins):
     print("\n")
 
 if graph:
-    fh = open("%s.udg" % graph_name, "w+")
+    fh = open("%s.udg" % graph_name, "w+", encoding="utf-8")
     fh.write(graph.render_graph_udraw())
     fh.close()

--- a/utils/ida_fuzz_library_extender.py
+++ b/utils/ida_fuzz_library_extender.py
@@ -156,13 +156,13 @@ start_address = SegByName(".idata")
 strings = find_strings(start_address)
 
 # write integers
-fh = open(constants_file, "w+")
+fh = open(constants_file, "w+", encoding="utf-8")
 for c in constants:
     fh.write(c + "\n")
 fh.close()
 
 # write strings
-fh = open(strings_file, "w+")
+fh = open(strings_file, "w+", encoding="utf-8")
 for s in strings:
     fh.write(s + "\n")
 fh.close()


### PR DESCRIPTION
Not specifying encoding when writing a file can cause UnicodeEncodeError because Python assumes the string's characters can fit in the OS's default text encoding, but that's often an invalid assumption. [Read more](https://codereview.doctor/features/python/best-practice/file-open-write-encoding)