### PR TITLE
Remove redundant inheritance of Object class

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ v0.4.2
 Features
 ^^^^^^^^
 - Remove six compatibility module
+- Remove specifying object inheritance in classes
 
 Fixes
 ^^^^^

--- a/boofuzz/__init__.py
+++ b/boofuzz/__init__.py
@@ -292,7 +292,7 @@ def s_block(name=None, group=None, encoder=None, dep=None, dep_value=None, dep_v
     :param dep_compare: (Optional, def="==") Comparison method to use on dependency (==, !=, >, >=, <, <=)
     """
 
-    class ScopedBlock(object):
+    class ScopedBlock:
         def __init__(self, block):
             self.block = block
 
@@ -335,7 +335,7 @@ def s_aligned(modulus=1, pattern=b"\x00", name=None):
                         be given, defaults to None
     """
 
-    class ScopedAligned(object):
+    class ScopedAligned:
         def __init__(self, aligned):
             self.aligned = aligned
 

--- a/boofuzz/cli_context.py
+++ b/boofuzz/cli_context.py
@@ -4,7 +4,7 @@ from .sessions import Session
 
 
 @attr.s
-class CliContext(object):
+class CliContext:
     """Context for Click commands' Context.obj"""
 
     session = attr.ib(type=Session)

--- a/boofuzz/connections/iserial_like.py
+++ b/boofuzz/connections/iserial_like.py
@@ -4,7 +4,7 @@ from future.utils import with_metaclass
 
 
 # abc.ABCMeta is the metaclass in both python 2 and 3
-class ISerialLike(with_metaclass(abc.ABCMeta, object)):
+class ISerialLike(with_metaclass(abc.ABCMeta)):
     """
     A serial-like interface, based on the pySerial module,
     the notable difference being that open() must always be called after the object is first created.

--- a/boofuzz/connections/itarget_connection.py
+++ b/boofuzz/connections/itarget_connection.py
@@ -4,7 +4,7 @@ from future.utils import with_metaclass
 
 
 # abc.ABCMeta is the metaclass in both python 2 and 3
-class ITargetConnection(with_metaclass(abc.ABCMeta, object)):
+class ITargetConnection(with_metaclass(abc.ABCMeta)):
     """
     Interface for connections to fuzzing targets.
     Target connections may be opened and closed multiple times. You must open before using send/recv and close

--- a/boofuzz/data_test_case.py
+++ b/boofuzz/data_test_case.py
@@ -6,7 +6,7 @@ from . import helpers
 
 
 @attr.s
-class DataTestCase(object):
+class DataTestCase:
     name = attr.ib()
     index = attr.ib()
     timestamp = attr.ib()

--- a/boofuzz/data_test_step.py
+++ b/boofuzz/data_test_step.py
@@ -6,7 +6,7 @@ from . import helpers
 
 
 @attr.s
-class DataTestStep(object):
+class DataTestStep:
     type = attr.ib()
     description = attr.ib()
     data = attr.ib()

--- a/boofuzz/event_hook.py
+++ b/boofuzz/event_hook.py
@@ -1,4 +1,4 @@
-class EventHook(object):
+class EventHook:
     """
     An EventHook that registers events using +=and -=.
 

--- a/boofuzz/fuzz_logger_db.py
+++ b/boofuzz/fuzz_logger_db.py
@@ -232,7 +232,7 @@ class FuzzLoggerDb(ifuzz_logger_backend.IFuzzLoggerBackend):
             query[4] = buffer(query[4][: self._data_truncate_length])
 
 
-class FuzzLoggerDbReader(object):
+class FuzzLoggerDbReader:
     """Read fuzz data saved using FuzzLoggerDb
 
     Args:

--- a/boofuzz/fuzzable.py
+++ b/boofuzz/fuzzable.py
@@ -1,4 +1,3 @@
-from future.builtins import object
 from future.moves import itertools
 
 from boofuzz.mutation import Mutation
@@ -6,7 +5,7 @@ from .mutation_context import MutationContext
 from .protocol_session_reference import ProtocolSessionReference
 
 
-class Fuzzable(object):
+class Fuzzable:
     """Parent class for all primitives and blocks.
 
     When making new fuzzable types, one will typically override :meth:`mutations` and/or :meth:`encode`.

--- a/boofuzz/fuzzers.py
+++ b/boofuzz/fuzzers.py
@@ -1,7 +1,7 @@
 from .exception import MustImplementException
 
 
-class Fuzzer(object):
+class Fuzzer:
     blocks = []
 
     def __init__(self):

--- a/boofuzz/ifuzz_logger.py
+++ b/boofuzz/ifuzz_logger.py
@@ -4,7 +4,7 @@ from future.utils import with_metaclass
 
 
 # abc.ABCMeta is the metaclass in both python 2 and 3
-class IFuzzLogger(with_metaclass(abc.ABCMeta, object)):
+class IFuzzLogger(with_metaclass(abc.ABCMeta)):
     """
     Abstract class for logging fuzz data.
 

--- a/boofuzz/monitors/pedrpc.py
+++ b/boofuzz/monitors/pedrpc.py
@@ -10,7 +10,7 @@ import uuid
 from boofuzz import exception
 
 
-class Client(object):
+class Client:
     def __init__(self, host, port):
         self.__host = host
         self.__port = port
@@ -203,7 +203,7 @@ class Client(object):
         return
 
 
-class Server(object):
+class Server:
     """
     The main PED-RPC Server class. To implement an RPC server, inherit from this class. Call ``serve_forever`` to start
     listening for RPC commands.

--- a/boofuzz/mutation.py
+++ b/boofuzz/mutation.py
@@ -2,7 +2,7 @@ import attr
 
 
 @attr.s
-class Mutation(object):
+class Mutation:
     value = attr.ib(type=bytes)
     qualified_name = attr.ib(type=str)
     index = attr.ib(type=int)

--- a/boofuzz/mutation_context.py
+++ b/boofuzz/mutation_context.py
@@ -14,7 +14,7 @@ def mutations_list_to_dict(mutations_list_or_dict):
 
 
 @attr.s
-class MutationContext(object):
+class MutationContext:
     """Context for current mutation(s).
 
     MutationContext objects are created by Session (the fuzz session manager) and passed to various Fuzzable functions

--- a/boofuzz/pgraph/cluster.py
+++ b/boofuzz/pgraph/cluster.py
@@ -14,7 +14,7 @@
 #
 
 
-class Cluster(object):
+class Cluster:
 
     id = None
     nodes = []

--- a/boofuzz/pgraph/edge.py
+++ b/boofuzz/pgraph/edge.py
@@ -14,10 +14,9 @@
 #
 
 import pydot
-from builtins import object
 
 
-class Edge(object):
+class Edge:
     id = None
     src = None
     dst = None

--- a/boofuzz/pgraph/graph.py
+++ b/boofuzz/pgraph/graph.py
@@ -16,11 +16,10 @@
 import copy
 
 import pydot
-from builtins import object
 from future.utils import listvalues
 
 
-class Graph(object):
+class Graph:
     """
     @todo: Add support for clusters
     @todo: Potentially swap node list with a node dictionary for increased performance

--- a/boofuzz/pgraph/node.py
+++ b/boofuzz/pgraph/node.py
@@ -14,10 +14,9 @@
 #
 
 import pydot
-from future.builtins import object
 
 
-class Node(object):
+class Node:
     id = 0
     number = 0
 

--- a/boofuzz/protocol_session.py
+++ b/boofuzz/protocol_session.py
@@ -2,7 +2,7 @@ import attr
 
 
 @attr.s
-class ProtocolSession(object):
+class ProtocolSession:
     """Contains a ``session_variables`` dictionary used to store data specific to a single fuzzing test case.
 
     Generally, values in ``session_variables`` will be set in a callback function, e.g. ``post_test_case_callbacks``

--- a/boofuzz/protocol_session_reference.py
+++ b/boofuzz/protocol_session_reference.py
@@ -2,7 +2,7 @@ import attr
 
 
 @attr.s
-class ProtocolSessionReference(object):
+class ProtocolSessionReference:
     """Refers to a dynamic value received or generated in the context of an individual test case.
 
     Pass this object as a primitive's ``default_value`` argument, and make sure you set the referred-to value using

--- a/boofuzz/repeater.py
+++ b/boofuzz/repeater.py
@@ -2,7 +2,7 @@ import time
 from abc import ABCMeta, abstractmethod
 
 
-class Repeater(object, metaclass=ABCMeta):
+class Repeater(metaclass=ABCMeta):
     """Base Repeater class.
 
     :param sleep_time: Time to sleep between repetitions.

--- a/boofuzz/sessions.py
+++ b/boofuzz/sessions.py
@@ -39,7 +39,7 @@ from boofuzz.web.app import app
 from .exception import BoofuzzFailure
 
 
-class Target(object):
+class Target:
     """Target descriptor container.
 
     Takes an ITargetConnection and wraps send/recv with appropriate
@@ -258,7 +258,7 @@ class Connection(pgraph.Edge):
         self.callback = callback
 
 
-class SessionInfo(object):
+class SessionInfo:
     def __init__(self, db_filename):
         self._db_reader = fuzz_logger_db.FuzzLoggerDbReader(db_filename=db_filename)
 
@@ -336,7 +336,7 @@ class SessionInfo(object):
         return ""
 
 
-class WebApp(object):
+class WebApp:
     """Serve fuzz data over HTTP.
 
     Args:

--- a/unit_tests/conftest.py
+++ b/unit_tests/conftest.py
@@ -3,7 +3,7 @@ import pytest
 
 @pytest.fixture
 def context():
-    class Context(object):
+    class Context:
         pass
 
     return Context()

--- a/unit_tests/test_session_failure_handling.py
+++ b/unit_tests/test_session_failure_handling.py
@@ -25,7 +25,7 @@ THREAD_WAIT_TIMEOUT = 10  # Time to wait for a thread before considering it fail
 # TODO how to share MiniTestServer and THREAD_WAIT_TIMEOUT with test_socket_connection.py
 
 
-class MiniTestServer(object):
+class MiniTestServer:
     """
     Small server class for testing SocketConnection.
     """

--- a/unit_tests/test_socket_connection.py
+++ b/unit_tests/test_socket_connection.py
@@ -144,7 +144,7 @@ def ethernet_frame(payload, src_mac, dst_mac, ether_type=ETHER_TYPE_IPV4):
     return raw_packet
 
 
-class MiniTestServer(object):
+class MiniTestServer:
     """
     Small server class for testing SocketConnection.
     """


### PR DESCRIPTION
Since we're now exclusively python3, a class is inherited from object by default, so explicitly inheriting from object is redundant. Removing it keeps the code simpler. [Read more](https://codereview.doctor/features/python/best-practice/avoid-inheriting-from-object)