### PR TITLE
Change type of default_value to bytes in FromFile

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Features
 Fixes
 ^^^^^
 - Specified encoding on file write rather than assuming default encoding
+- Changed type of `default_value` from string to bytes for `FromFile`.
 
 v0.4.1
 ------

--- a/boofuzz/__init__.py
+++ b/boofuzz/__init__.py
@@ -768,12 +768,12 @@ def s_string(value="", size=None, padding=b"\x00", encoding="ascii", fuzzable=Tr
     )
 
 
-def s_from_file(value="", filename=None, encoding="ascii", fuzzable=True, max_len=0, name=None):
+def s_from_file(value=b"", filename=None, encoding="ascii", fuzzable=True, max_len=0, name=None):
     """
     Push a value from file onto the current block stack.
 
-    :type  value:    str
-    :param value:    (Optional, def="") Default string value
+    :type  value:    bytes
+    :param value:    (Optional, def=b"") Default bytes value
     :type  filename: str
     :param filename: (Optional, def=None) Filename pattern to load all fuzz value
     :type  encoding: str

--- a/boofuzz/primitives/from_file.py
+++ b/boofuzz/primitives/from_file.py
@@ -13,8 +13,8 @@ class FromFile(BasePrimitive):
     :type  name: str, optional
     :param name: Name, for referencing later. Names should always be provided, but if not, a default name will be given,
         defaults to None
-    :type  default_value: str
-    :param default_value: Default string value
+    :type  default_value: bytes
+    :param default_value: Default bytes value
     :type  filename: str
     :param filename: Filename pattern to load all fuzz value
     :type  max_len: int, optional
@@ -23,7 +23,7 @@ class FromFile(BasePrimitive):
     :param fuzzable: Enable/disable fuzzing of this primitive, defaults to true
     """
 
-    def __init__(self, name=None, default_value="", filename=None, max_len=0, *args, **kwargs):
+    def __init__(self, name=None, default_value=b"", filename=None, max_len=0, *args, **kwargs):
 
         super(FromFile, self).__init__(name=name, default_value=default_value, *args, **kwargs)
 


### PR DESCRIPTION
`FromFile` and `s_from_file` no longer support encoding their values.
The supplied files are opened in `rb` mode, so no encoding is needed.
To match the type, `default_value` should also be of type `bytes` rather than string.

Fixes #613 