### PR TITLE
Disable pytype on stickler-ci

### DIFF
--- a/.stickler.yml
+++ b/.stickler.yml
@@ -9,6 +9,3 @@ linters:
     python: 3
     config: ./setup.cfg
     fixer: true
-  pytype:
-    config: ./setup.cfg
-    fixer: false

--- a/boofuzz/fuzzable.py
+++ b/boofuzz/fuzzable.py
@@ -129,6 +129,7 @@ class Fuzzable:
 
         """
         try:
+            pass
             if not self.fuzzable:
                 return
             index = 0

--- a/boofuzz/fuzzable.py
+++ b/boofuzz/fuzzable.py
@@ -129,7 +129,6 @@ class Fuzzable:
 
         """
         try:
-            pass
             if not self.fuzzable:
                 return
             index = 0


### PR DESCRIPTION
Stickler CI is failing a lot recently because of timeouts. Pytype seems to run too long so after 5 minutes the run gets aborted.