### PR TITLE
Fixed minimum python version in INSTALL.rst

### DIFF
--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -4,7 +4,7 @@ Installing boofuzz
 Prerequisites
 -------------
 
-Boofuzz requires Python ≥ 3.5. Recommended installation requires ``pip``. As a base requirement, the following packages
+Boofuzz requires Python ≥ 3.6. Recommended installation requires ``pip``. As a base requirement, the following packages
 are needed:
 
 Ubuntu/Debian


### PR DESCRIPTION
Changelog says that since v0.4.0, the minimum version is python 3.6, while INSTALL.rst (and thus the docs) still say python 3.5.

I'll assume that 3.6 is correct, this PR fixes the docs.