### PR TITLE
Proposal: Add anchors for protocol-definition.rst

### DIFF
--- a/docs/user/protocol-definition.rst
+++ b/docs/user/protocol-definition.rst
@@ -47,28 +47,83 @@ Request
 
 Blocks
 ------
+Block
+^^^^^
 .. autofunction:: boofuzz.Block
+
+Checksum
+^^^^^^^^
 .. autofunction:: boofuzz.Checksum
+
+Repeat
+^^^^^^
 .. autofunction:: boofuzz.Repeat
+
+Size
+^^^^
 .. autofunction:: boofuzz.Size
+
+Aligned
+^^^^^^^
 .. autofunction:: boofuzz.Aligned
 
 Primitives
 ----------
 
+Static
+^^^^^^
 .. autofunction:: boofuzz.Static
+
+Simple
+^^^^^^
 .. autofunction:: boofuzz.Simple
+
+Delim
+^^^^^
 .. autofunction:: boofuzz.Delim
+
+Group
+^^^^^
 .. autofunction:: boofuzz.Group
+
+RandomData
+^^^^^^^^^^
 .. autofunction:: boofuzz.RandomData
+
+String
+^^^^^^
 .. autofunction:: boofuzz.String
+
+FromFile
+^^^^^^^^
 .. autofunction:: boofuzz.FromFile
+
+Mirror
+^^^^^^
 .. autofunction:: boofuzz.Mirror
+
+BitField
+^^^^^^^^
 .. autofunction:: boofuzz.BitField
+
+Byte
+^^^^
 .. autofunction:: boofuzz.Byte
+
+Bytes
+^^^^^
 .. autofunction:: boofuzz.Bytes
+
+Word
+^^^^
 .. autofunction:: boofuzz.Word
+
+DWord
+^^^^^
 .. autofunction:: boofuzz.DWord
+
+QWord
+^^^^^
 .. autofunction:: boofuzz.QWord
 
 .. _custom-blocks:


### PR DESCRIPTION
I thought it would be nice to have the blocks and primitives listed in the navigation tree on the left. For that I've added headings for each autofunction.

The result will look like this:
![grafik](https://user-images.githubusercontent.com/46794237/183753765-de998bf6-c715-4354-9fd3-e4be6848d5a6.png)

Any thoughts?