### PR TITLE
Fix invalid data type in socket tests

### DIFF
--- a/unit_tests/helpers_udp_checksum.feature
+++ b/unit_tests/helpers_udp_checksum.feature
@@ -29,7 +29,7 @@ Feature: helpers.udp_checksum()
         Then The result is 0x4E36
     
     Scenario: Msg 60 bytes
-        Given msg with 60 bytes
+        Given Message with 60 bytes
         And src_addr 192.168.0.12
         And dst_addr 255.255.255.255
         When Calling udp_checksum

--- a/unit_tests/test_helpers_udp_checksum.py
+++ b/unit_tests/test_helpers_udp_checksum.py
@@ -22,7 +22,7 @@ def msg_1_byte(context, msg):
     context.msg = ast.literal_eval(msg)
 
 
-@given("msg with 60 bytes")
+@given("Message with 60 bytes")
 def msg_60_bytes(context):
     # Use each bit at least once...
     all_16_bits = (

--- a/unit_tests/test_socket_connection.py
+++ b/unit_tests/test_socket_connection.py
@@ -446,7 +446,7 @@ class TestSocketConnection(unittest.TestCase):
 
         # Given
         server = MiniTestServer(proto="raw", host="lo")
-        server.data_to_send = "GKC"
+        server.data_to_send = b"GKC"
         server.bind()
 
         uut = SocketConnection(host="lo", proto="raw-l2", recv_timeout=0.1)
@@ -499,7 +499,7 @@ class TestSocketConnection(unittest.TestCase):
 
         # Given
         server = MiniTestServer(proto="raw", host="lo")
-        server.data_to_send = "GKC"
+        server.data_to_send = b"GKC"
         server.bind()
 
         uut = SocketConnection(host="lo", proto="raw-l2", recv_timeout=0.1)
@@ -545,7 +545,7 @@ class TestSocketConnection(unittest.TestCase):
 
         # Given
         server = MiniTestServer(proto="raw", host="lo")
-        server.data_to_send = "GKC"
+        server.data_to_send = b"GKC"
         server.bind()
 
         uut = SocketConnection(host="lo", proto="raw-l2", recv_timeout=0.1)
@@ -595,7 +595,7 @@ class TestSocketConnection(unittest.TestCase):
 
         # Given
         server = MiniTestServer(proto="raw", host="lo")
-        server.data_to_send = "GKC"
+        server.data_to_send = b"GKC"
         server.bind()
 
         uut = SocketConnection(host="lo", proto="raw-l3")
@@ -644,7 +644,7 @@ class TestSocketConnection(unittest.TestCase):
 
         # Given
         server = MiniTestServer(proto="raw", host="lo")
-        server.data_to_send = "GKC"
+        server.data_to_send = b"GKC"
         server.bind()
 
         uut = SocketConnection(host="lo", proto="raw-l3")
@@ -690,7 +690,7 @@ class TestSocketConnection(unittest.TestCase):
 
         # Given
         server = MiniTestServer(proto="raw", host="lo")
-        server.data_to_send = "GKC"
+        server.data_to_send = b"GKC"
         server.bind()
 
         uut = SocketConnection(host="lo", proto="raw-l3")


### PR DESCRIPTION
This error has been around a long while.
With recent changes to pytest it now makes the tests fail.