### PR TITLE
Fix Linux tox builds

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -8,11 +8,11 @@ platform =
     Windows: win32
     Linux: linux
     macOS: darwin
-whitelist_externals = bash
+allowlist_externals = sh
 extras = dev
 commands =
     pip check
-    Linux: bash -ec "if ! getcap $(realpath {envpython}) | grep -q cap_net_admin,cap_net_raw+eip; then sudo setcap cap_net_admin,cap_net_raw+eip $(realpath {envpython}); fi"
+    Linux: sh -ec "if ! getcap $(realpath {envpython}) | grep -q cap_net_admin,cap_net_raw+eip; then sudo setcap cap_net_admin,cap_net_raw+eip $(realpath {envpython}); fi"
     pytest --cov --cov-report=xml
     check-manifest
 commands_post =


### PR DESCRIPTION
`whitelist_externals` was renamed to `allowlist_externals`