### PR TITLE
Flush log data when closing the test.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ Fixes
 - Changed type of `default_value` from string to bytes for `FromFile`.
 - `s_update` primitive was out of date.
 - The minimum supported Python version is now 3.7.
+- Flush log data when closing the test.
 
 v0.4.1
 ------

--- a/boofuzz/fuzz_logger_csv.py
+++ b/boofuzz/fuzz_logger_csv.py
@@ -1,6 +1,6 @@
+import sys
 import csv
 import datetime
-import sys
 
 from . import helpers, ifuzz_logger_backend
 
@@ -37,6 +37,7 @@ class FuzzLoggerCsv(ifuzz_logger_backend.IFuzzLoggerBackend):
             file_handle (io.BinaryIO): Open file handle for logging. Defaults to sys.stdout.
             bytes_to_str (function): Function that converts sent/received bytes data to string for logging.
         """
+        file: file_handle
         self._file_handle = file_handle
         self._format_raw_bytes = bytes_to_str
         self._csv_handle = csv.writer(self._file_handle)
@@ -72,6 +73,9 @@ class FuzzLoggerCsv(ifuzz_logger_backend.IFuzzLoggerBackend):
         pass
 
     def close_test(self):
+        # At this point any buffered data in the file must be flushed to prevent loss.
+        # Issue 601 https://github.com/jtpereyda/boofuzz/issues/601
+        print("", file=self._file_handle, flush=True)
         pass
 
     def _print_log_msg(self, msg):

--- a/boofuzz/fuzz_logger_text.py
+++ b/boofuzz/fuzz_logger_text.py
@@ -68,4 +68,5 @@ class FuzzLoggerText(ifuzz_logger_backend.IFuzzLoggerBackend):
         print(
             helpers.format_log_msg(msg_type=msg_type, description=msg, data=data, indent_size=self.INDENT_SIZE),
             file=self._file_handle,
+            flush=True,
         )


### PR DESCRIPTION
https://github.com/jtpereyda/boofuzz/issues/601
Text log file and CSV log file requires a file flush so the data is consistent with the boofuzz db file. Amended file formatting using the results of the "black" program.