### PR TITLE
Fix: `BitField` mutations deduplication

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,7 @@ Fixes
 - Changed type of `default_value` from string to bytes for `FromFile`.
 - `s_update` primitive was out of date.
 - The minimum supported Python version is now 3.7.
+- Removed duplicates from `BitField` primitive.
 
 v0.4.1
 ------

--- a/boofuzz/primitives/bit_field.py
+++ b/boofuzz/primitives/bit_field.py
@@ -87,7 +87,7 @@ class BitField(Fuzzable):
 
         if not self.max_num:
             self.max_num = binary_string_to_int("1" + "0" * width)
-            
+
         assert isinstance(self.max_num, int), "max_num must be an integer!"
 
         if not self.full_range:
@@ -102,7 +102,7 @@ class BitField(Fuzzable):
                 self.max_num // 32,
                 self.max_num,
             ]
-            
+
             # Contract: sort in ascending order required for deduplication.
             interesting_boundaries.sort()
 

--- a/boofuzz/primitives/bit_field.py
+++ b/boofuzz/primitives/bit_field.py
@@ -137,6 +137,7 @@ class BitField(Fuzzable):
         @type  lower_border: int
         @param lower_border: int bottom limit for border cases, so all values must be strictly greater
         """
+        # Contract: generate values in ascending order, otherwise deduplication logics might break.
         for i in range(-10, 10):
             case = integer + i
             if lower_border < case < self.max_num:

--- a/boofuzz/primitives/bit_field.py
+++ b/boofuzz/primitives/bit_field.py
@@ -106,8 +106,20 @@ class BitField(Fuzzable):
                 self.max_num // 32,
                 self.max_num,
             ]
+
+            # To avoid duplication of mutation params, we introduce gradually
+            # increasing lower border. We also require interesting borders to be
+            # sorted in ascending order to be processed correctly.
+            # Deduplication could also be done with intermediate 'set' construction,
+            # but it might be costly or impossible if the number of values is huge.
+            interesting_boundaries.sort()
+
+            # We don't expect negative bit field values with Python integers,
+            # the 0-value is possible with the given starting 'lower_border'.
+            lower_border = -1
             for boundary in interesting_boundaries:
-                for v in self._yield_integer_boundaries(boundary):
+                for v in self._yield_integer_boundaries(boundary, lower_border):
+                    lower_border = v
                     yield v
         # TODO Add a way to inject a list of fuzz values
         # elif isinstance(default_value, (list, tuple)):
@@ -116,16 +128,18 @@ class BitField(Fuzzable):
 
         # TODO: Add injectable arbitrary bit fields
 
-    def _yield_integer_boundaries(self, integer):
+    def _yield_integer_boundaries(self, integer, lower_border):
         """
         Add the supplied integer and border cases to the integer fuzz heuristics library.
 
         @type  integer: int
         @param integer: int to append to fuzz heuristics
+        @type  lower_border: int
+        @param lower_border: int bottom limit for border cases, so all values must be strictly greater
         """
         for i in range(-10, 10):
             case = integer + i
-            if 0 <= case < self.max_num:
+            if lower_border < case < self.max_num:
                 # some day: if case not in self._user_provided_values
                 yield case
 

--- a/unit_tests/test_primitives.py
+++ b/unit_tests/test_primitives.py
@@ -105,6 +105,23 @@ class TestPrimitives(unittest.TestCase):
                 req.resolve_name(context_path="test_s_mirror", name="size").render(),
             )
 
+    def test_bit_field(self):
+        s_initialize("test_bit_field")
+        s_bit_field(0, width=4, name="bit_field")
+        req = s_get("test_bit_field")
+
+        mutated_values = []
+        mutations_generator = req.get_mutations()
+        for mutations_list in mutations_generator:
+            self.assertEqual(len(mutations_list), 1)
+            mutation = mutations_list[0]
+            self.assertEqual(mutation.qualified_name, "test_bit_field.bit_field")
+            mutated_values.append(mutation.value)
+
+        mutated_values_set = set(mutated_values)
+        # bit field mutations should not contain duplicates
+        self.assertEqual(len(mutated_values_set), len(mutated_values))
+
     def test_bytes(self):
         # test if s_bytes works with empty input
         s_initialize("test_bytes_empty")


### PR DESCRIPTION
### Problem

Sample script:

```
def test_duplicates():
    for width in range(1, 13):
        bit_field = BitField(width=width)
        values = [m for m in bit_field.mutations(default_value=0)]
        values_deduplicated = list(set(values))

        print(f"width: {width}")
        if width <= 6:
            print(f"{len(values)} {values}")
            print(f"{len(values_deduplicated)} {values_deduplicated}")
        else:
            print(f"{len(values)}")
            print(f"{len(values_deduplicated)}")
```

Sample output:

```
width: 1
16 [0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 1]
2 [0, 1]
width: 2
32 [0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3, 0, 1, 2, 3]
4 [0, 1, 2, 3]
width: 3
64 [0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7]
8 [0, 1, 2, 3, 4, 5, 6, 7]
width: 4
98 [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
16 [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
width: 5
115 [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31]
32 [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31]
width: 6
124 [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63]
52 [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63]
width: 7
132
82
width: 8
138
112
width: 9
140
132
width: 10
140
140
width: 11
140
140
width: 12
140
140
```

This means that existing implementation of `BitField` mutations generator generates duplicating values for `width`s <= 9

### Solution

- Generate mutations in strictly ascending order to avoid duplicates
- Add unit test to check for duplicates

Sample output after fix:

```
width: 1
2 [0, 1]
2 [0, 1]
width: 2
4 [0, 1, 2, 3]
4 [0, 1, 2, 3]
width: 3
8 [0, 1, 2, 3, 4, 5, 6, 7]
8 [0, 1, 2, 3, 4, 5, 6, 7]
width: 4
16 [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
16 [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15]
width: 5
32 [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31]
32 [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31]
width: 6
52 [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63]
52 [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 54, 55, 56, 57, 58, 59, 60, 61, 62, 63]
width: 7
82
82
width: 8
112
112
width: 9
132
132
width: 10
140
140
width: 11
140
140
width: 12
140
140
```