### PR TITLE
Disable tests for end-of-life Python 3.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        python-version: [3.7, 3.8, 3.9, "3.10", 3.11]
+        python-version: [3.8, 3.9, "3.10", 3.11]
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}

--- a/INSTALL.rst
+++ b/INSTALL.rst
@@ -4,7 +4,7 @@ Installing boofuzz
 Prerequisites
 -------------
 
-Boofuzz requires Python ≥ 3.7. Recommended installation requires ``pip``. As a base requirement, the following packages
+Boofuzz requires Python ≥ 3.8. Recommended installation requires ``pip``. As a base requirement, the following packages
 are needed:
 
 Ubuntu/Debian

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 minversion=2.0
 skip_missing_interpreters = True
-envlist = py{37,38,39,310,311}-{Linux,Windows,macOS}, docs, lint
+envlist = py{38,39,310,311}-{Linux,Windows,macOS}, docs, lint
 
 [testenv]
 platform =


### PR DESCRIPTION
Python 3.7 has reached it's end of life https://devguide.python.org/versions/

Supporting it would hold us back from upgrading some dependencies like tox.