### PR TITLE
Add lint stage to GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -55,3 +55,17 @@ jobs:
       run: python -m pip install --upgrade pip tox
     - name: Run tox
       run: tox --skip-missing-interpreters false -e docs
+  lint:
+    name: Run linters
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.x
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.x'
+    - name: Install pip and tox
+      run: python -m pip install --upgrade pip tox
+    - name: Run tox
+      run: tox --skip-missing-interpreters false -e lint


### PR DESCRIPTION
Since Stickler-CI is no longer available, we should run our linters in GH Actions.