### PR TITLE
Update .readthedocs.yml to comply with the current standard

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -11,12 +11,16 @@ formats:
   - pdf
 
 python:
-   version: 3
    install:
       - method: pip
         path: .
         extra_requirements:
            - docs
+
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3"
 
 sphinx:
   # The path to the conf.py file


### PR DESCRIPTION
Our current config will be deprecated on 16th of October, see https://blog.readthedocs.com/use-build-os-config/

This will bring us up to date again.