### PR TITLE
Ignore stackoverflow.com in linkcheck

### DIFF
--- a/boofuzz/event_hook.py
+++ b/boofuzz/event_hook.py
@@ -2,7 +2,7 @@ class EventHook:
     """
     An EventHook that registers events using +=and -=.
 
-    Based on spassig's solution here: http://stackoverflow.com/a/1094423/461834
+    Based on spassig's solution here: https://stackoverflow.com/a/1094423/461834
     """
 
     def __init__(self):

--- a/boofuzz/event_hook.py
+++ b/boofuzz/event_hook.py
@@ -2,7 +2,7 @@ class EventHook:
     """
     An EventHook that registers events using +=and -=.
 
-    Based on spassig's solution here: https://stackoverflow.com/a/1094423
+    Based on spassig's solution here: http://stackoverflow.com/a/1094423/461834
     """
 
     def __init__(self):

--- a/boofuzz/event_hook.py
+++ b/boofuzz/event_hook.py
@@ -2,7 +2,7 @@ class EventHook:
     """
     An EventHook that registers events using +=and -=.
 
-    Based on spassig's solution here: http://stackoverflow.com/a/1094423/461834
+    Based on spassig's solution here: https://stackoverflow.com/a/1094423
     """
 
     def __init__(self):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -79,6 +79,7 @@ todo_include_todos = False
 
 linkcheck_ignore = [
     r"https://twitter.com/b00fuzz",
+    r"https://stackoverflow.com",
 ]
 
 


### PR DESCRIPTION
Link checks to stackoverflow.com result in 403 forbidden in GH Actions.