### PR TITLE
Support modifying the message, such as encryption.

### DIFF
--- a/boofuzz/sessions/session.py
+++ b/boofuzz/sessions/session.py
@@ -138,6 +138,8 @@ class Session(pgraph.Graph):
         target=None,
         web_address=constants.DEFAULT_WEB_UI_ADDRESS,
         db_filename=None,
+        mutation_context=None,
+        modified_data=False
     ):
         self._ignore_connection_reset = ignore_connection_reset
         self._ignore_connection_aborted = ignore_connection_aborted
@@ -858,6 +860,9 @@ class Session(pgraph.Graph):
         else:
             data = self.fuzz_node.render(mutation_context)
 
+        if self.modified_data:
+            data = self.modified_data
+            self.modified_data = False
         try:  # send
             self.targets[0].send(data)
             self.last_send = data
@@ -1081,6 +1086,8 @@ class Session(pgraph.Graph):
                 ):
                     self._fuzz_data_logger.open_test_step("restart interval of %d reached" % self.restart_interval)
                     self._restart_target(self.targets[0])
+
+                self.mutation_context = mutation_context
 
                 self._fuzz_current_case(mutation_context)
 

--- a/boofuzz/sessions/session.py
+++ b/boofuzz/sessions/session.py
@@ -149,6 +149,7 @@ class Session(pgraph.Graph):
 
         super(Session, self).__init__()
 
+        self.modified_data = modified_data
         self.session_filename = session_filename
         self._index_start = max(index_start, 1)
         self._index_end = index_end


### PR DESCRIPTION
I made modifications to session.py to support obtaining and modifying the mutated version of the message before sending it. To encrypt the fields requiring encryption in the message, you can use the following method:
```python
secret_key = None

def pre_send_callback(target, fuzz_data_logger, session, sock):
    mc = session.mutation_context

    # Method 1:
    # The mutated data packet to be sent
    original_data = session.fuzz_node.render(mc).hex()
    if secret_key:
        modified_data = original_data^secret_key
    session.modified_data = modified_data

    # Method 2:
    if list(mc.mutations.keys())[0] == "field requiring encryption"
        mc.mutations[list(mc.mutations.keys())[0]].value ^= secret_key

def post_test_case_callback(target, fuzz_data_logger, session, sock):
    if not secret_key:
        receive_data = session.last_recv.hex()
        secret_key = get_secret_key(receive_data)

session = Session(target=Target(SocketConnection(host, int(port))),receive_data_after_fuzz=True,,post_test_case_callbacks=[post_test_case_callback],pre_send_callbacks=[pre_send_callback])
```