### PR TITLE
Handle TLS handshake timeouts in SSLSocketConnection

### DIFF
--- a/boofuzz/connections/ssl_socket_connection.py
+++ b/boofuzz/connections/ssl_socket_connection.py
@@ -54,7 +54,21 @@ class SSLSocketConnection(tcp_socket_connection.TCPSocketConnection):
             # No SSL context set
             pass
 
-        super(SSLSocketConnection, self)._connect_socket()
+        # The wrapped SSL Socket does not have the timeout that is confiugred
+        # in BaseSocketConnection but needs the timeout to be configured 
+        # through the SSLSocket class
+        self._sock.settimeout(self._recv_timeout)
+
+        try:
+            super(SSLSocketConnection, self)._connect_socket()
+        except TimeoutError as e:
+            # This TimeoutError is raised by the SSL layer during the TLS 
+            # handshake, e.g. when the TCP connection could be established
+            # but the TLS handshakes times out. All other errors are handled
+            # by the parent class
+            raise exception.BoofuzzTargetConnectionFailedError(str(e))
+        else:
+            raise
 
     def recv(self, max_bytes):
         """

--- a/boofuzz/connections/ssl_socket_connection.py
+++ b/boofuzz/connections/ssl_socket_connection.py
@@ -54,18 +54,15 @@ class SSLSocketConnection(tcp_socket_connection.TCPSocketConnection):
             # No SSL context set
             pass
 
-        # The wrapped SSL Socket does not have the timeout that is confiugred
-        # in BaseSocketConnection but needs the timeout to be configured 
-        # through the SSLSocket class
+        # The wrapped SSL Socket does not have the timeout that is configured in BaseSocketConnection but needs the
+        # timeout to be configured through the SSLSocket class
         self._sock.settimeout(self._recv_timeout)
 
         try:
             super(SSLSocketConnection, self)._connect_socket()
         except TimeoutError as e:
-            # This TimeoutError is raised by the SSL layer during the TLS 
-            # handshake, e.g. when the TCP connection could be established
-            # but the TLS handshakes times out. All other errors are handled
-            # by the parent class
+            # This TimeoutError is raised by the SSL layer during the TLS handshake, e.g. when the TCP connection could
+            # be established but the TLS handshakes times out. All other errors are handled by the parent class
             raise exception.BoofuzzTargetConnectionFailedError(str(e))
         else:
             raise


### PR DESCRIPTION
SSLSocketConnection prior to this commit would hang identifitly if a timeout during the TLS handshake occurs. This can happen if a target accepts a TCP connection but does not send any TLS handshake messages, e.g. because of a bug triggered by the fuzzing.

This commit makes boofuzz observe timeouts during the TLS handshake. TLS handshake timeouts are handled in the same way as timeouts during TCP connection setup.