### PR TITLE
Resolve datetime deprecation warnings

### DIFF
--- a/boofuzz/fuzz_logger_csv.py
+++ b/boofuzz/fuzz_logger_csv.py
@@ -21,7 +21,7 @@ DEFAULT_HEX_TO_STR = hex_to_hexstr
 
 
 def get_time_stamp():
-    s = datetime.datetime.now(datetime.UTC).replace(tzinfo=None).isoformat()
+    s = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None).isoformat()
     return s
 
 

--- a/boofuzz/fuzz_logger_csv.py
+++ b/boofuzz/fuzz_logger_csv.py
@@ -21,7 +21,7 @@ DEFAULT_HEX_TO_STR = hex_to_hexstr
 
 
 def get_time_stamp():
-    s = datetime.datetime.utcnow().isoformat()
+    s = datetime.datetime.now(datetime.UTC).replace(tzinfo=None).isoformat()
     return s
 
 

--- a/boofuzz/fuzz_logger_db.py
+++ b/boofuzz/fuzz_logger_db.py
@@ -26,7 +26,7 @@ DEFAULT_HEX_TO_STR = hex_to_hexstr
 
 
 def get_time_stamp():
-    s = datetime.datetime.now(datetime.UTC).replace(tzinfo=None).isoformat()
+    s = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None).isoformat()
     return s
 
 

--- a/boofuzz/fuzz_logger_db.py
+++ b/boofuzz/fuzz_logger_db.py
@@ -26,7 +26,7 @@ DEFAULT_HEX_TO_STR = hex_to_hexstr
 
 
 def get_time_stamp():
-    s = datetime.datetime.utcnow().isoformat()
+    s = datetime.datetime.now(datetime.UTC).replace(tzinfo=None).isoformat()
     return s
 
 
@@ -51,7 +51,7 @@ class FuzzLoggerDb(ifuzz_logger_backend.IFuzzLoggerBackend):
 
         self._current_test_case_index = 0
 
-        self._queue = collections.deque([])  # Queue that holds last n test cases before commiting
+        self._queue = collections.deque([])  # Queue that holds last n test cases before committing
         self._queue_max_len = num_log_cases
         self._fail_detected = False
         self._log_first_case = True

--- a/boofuzz/sessions/session.py
+++ b/boofuzz/sessions/session.py
@@ -171,7 +171,7 @@ class Session(pgraph.Graph):
             else:
                 fuzz_loggers = [fuzz_logger_text.FuzzLoggerText()]
 
-        self._run_id = datetime.datetime.utcnow().replace(microsecond=0).isoformat().replace(":", "-")
+        self._run_id = datetime.datetime.now(datetime.UTC).replace(microsecond=0).isoformat().replace(":", "-")
         if db_filename is not None:
             helpers.mkdir_safe(db_filename, file_included=True)
             self._db_filename = db_filename

--- a/boofuzz/sessions/session.py
+++ b/boofuzz/sessions/session.py
@@ -171,7 +171,7 @@ class Session(pgraph.Graph):
             else:
                 fuzz_loggers = [fuzz_logger_text.FuzzLoggerText()]
 
-        self._run_id = datetime.datetime.now(datetime.UTC).replace(microsecond=0).isoformat().replace(":", "-")
+        self._run_id = datetime.datetime.now(datetime.timezone.utc).replace(microsecond=0).isoformat().replace(":", "-")
         if db_filename is not None:
             helpers.mkdir_safe(db_filename, file_included=True)
             self._db_filename = db_filename


### PR DESCRIPTION
# PR Summary
This PR fixes the `DeprecationWarning` that appears in Python 3.12+ when using `datetime.utcnow()`. It replaces it with a more future-proof approach: `datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)`. This keeps the `datetime` object naive (without timezone info), which is important for parts of the code that expect it that way, but avoids the warning by using a timezone-aware method first:
```python
# Before (deprecated)  
from datetime import datetime  
naive_time = datetime.utcnow()  # Raises warning  

# Common Fix (timezone-aware)  
from datetime import datetime, timezone  
aware_time = datetime.datetime.now(datetime.timezone.utc)  # Breaks naive-dependent code  

# This PR's Fix (naive but compliant)  
from datetime import datetime, timezone  
compliant_time = datetime.datetime.now(datetime.timezone.utc).replace(tzinfo=None)  # No warning, backward-compatible  
```
You can see those warnings in the [latest CI run](https://github.com/jtpereyda/boofuzz/actions/runs/14686392649/job/41215521933#step:6:89):
```python
  D:\a\boofuzz\boofuzz\boofuzz\fuzz_logger_csv.py:24: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    s = datetime.datetime.utcnow().isoformat()

unit_tests/test_session_failure_handling.py::TestNoResponseFailure::test_no_response_causes_restart
  D:\a\boofuzz\boofuzz\boofuzz\sessions\session.py:174: DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
    self._run_id = datetime.datetime.utcnow().replace(microsecond=0).isoformat().replace(":", "-")
```