### PR TITLE
fix: correct interface parameter description in RawL2SocketConnection (#744)

### DIFF
--- a/boofuzz/connections/raw_l2_socket_connection.py
+++ b/boofuzz/connections/raw_l2_socket_connection.py
@@ -12,7 +12,7 @@ class RawL2SocketConnection(base_socket_connection.BaseSocketConnection):
     .. versionadded:: 0.2.0
 
     Args:
-        interface (str): Hostname or IP adress of target system.
+        interface (str): Interface to send and receive on.
         send_timeout (float): Seconds to wait for send before timing out. Default 5.0.
         recv_timeout (float): Seconds to wait for recv before timing out. Default 5.0.
         ethernet_proto (int): Ethernet protocol to bind to. If supplied, the opened socket


### PR DESCRIPTION
## Summary
- Fixes #744: Documentation incorrectly describes interface parameter
- Changed "Hostname or IP address" to "Interface to send and receive on"
- Parameter expects network interface name (e.g., "eth0"), not hostname/IP

## Changes
- `boofuzz/connections/raw_l2_socket_connection.py`: Updated docstring

## Test Plan
- [x] Documentation accurately reflects parameter purpose
- [x] No functional changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>